### PR TITLE
Add missing lodash dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "coloured-log": "0.9.7",
     "commander": "2.9.0",
     "debug": "2.2.0",
-    "knex": "0.12.5"
+    "knex": "0.12.5",
+    "lodash": "4.16.4"
   },
   "files": [
     "bin",


### PR DESCRIPTION
This makes the migrator actually function when installed globally :smile: