### PR TITLE
🎨  add help for DatabaseIsNotOkError error

### DIFF
--- a/lib/errors.js
+++ b/lib/errors.js
@@ -24,6 +24,7 @@ function KnexMigrateError(options) {
      */
     this.id = options.id || this.id;
     this.message = options.message || this.message;
+    this.help = options.help || this.help;
     this.code = options.code || this.code;
     this.errorType = this.name = options.errorType || this.errorType;
 
@@ -46,7 +47,8 @@ var errors = {
     DatabaseIsNotOkError: function DatabaseIsNotOkError(options) {
         KnexMigrateError.call(this, _.merge({
             id: 200,
-            errorType: 'DatabaseIsNotOkError'
+            errorType: 'DatabaseIsNotOkError',
+            help: 'If knex-migrator is not installed, please run "npm install -g knex-migrator" \nRead more here: https://github.com/TryGhost/knex-migrator'
         }, options));
     }
 };


### PR DESCRIPTION
refs #13
- add hint how to install knex-migrator
- add the repo url

```
[2016-11-01 11:55:22] ERROR

Please run knex-migrator init
level:normal

If knex-migrator is not installed, please run "npm install -g knex-migrator"
Read more here: https://github.com/TryGhost/knex-migrator
```

@ErisDS If you would like to change the description or add something, just tell me 👍 