### PR TITLE
🐛  current version behaviour

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -148,9 +148,7 @@ KnexMigrator.prototype.migrate = function migrate(options) {
     this.connection = database.connect(this.dbConfig);
 
     return self.createTransaction(function executeTasks(transacting) {
-        var folders = utils.readFolders(self.migrationPath),
-            operations = {},
-            versionsToMigrate = [];
+        var versionsToMigrate = [];
 
         return self.integrityCheck({
             transacting: transacting,
@@ -384,7 +382,7 @@ KnexMigrator.prototype.integrityCheck = function integrityCheck(options) {
         // if you current version if 1.0 and you add migration scripts for the next version 1.1
         // we won't execute them until your current version changes to 1.1
         if (self.currentVersion) {
-            if (folder > self.currentVersion) {
+            if (Number(folder) > Number(self.currentVersion)) {
                 return;
             }
         }

--- a/test/assets/.knex-migrator
+++ b/test/assets/.knex-migrator
@@ -9,5 +9,6 @@ module.exports = {
             filename: path.join(process.cwd(), 'test/assets/test.db')
         }
     },
-    migrationPath: path.join(process.cwd(), 'test/assets/migrations')
+    migrationPath: path.join(process.cwd(), 'test/assets/migrations'),
+    currentVersion: '1.4'
 }


### PR DESCRIPTION
no issue
- "init" > "1.0" is true and it can happen that the "init" folder get's ignored when making an integrity check
- add more tests for versionings
- ensure we compare numbers for versions