### PR TITLE
✨  detect global/local installation to avoid version incompatible beh…

### DIFF
--- a/bin/knex-migrator-health
+++ b/bin/knex-migrator-health
@@ -1,31 +1,35 @@
 #!/usr/bin/env node
 
-var KnexMigrator = require('../');
 var program = require('commander');
+var utils = require('../lib/utils');
 
 /**
  * @TODO: remove coloured-log (it can't print errors...)
  */
 var Log = require('coloured-log');
 var log = new Log(Log.INFO);
-var migrator;
+var knexMigrator;
 
-program
-    .parse(process.argv);
+utils.getKnexMigrator({path: process.cwd()})
+    .then(function (KnexMigrator) {
+        program
+            .parse(process.argv);
 
-try {
-    migrator = new KnexMigrator();
-} catch (err) {
-    log.error(err.message);
-    process.exit();
-}
+        try {
+            knexMigrator = new KnexMigrator();
+        } catch (err) {
+            log.error(err.message);
+            process.exit();
+        }
 
-return migrator.isDatabaseOK()
-    .then(function () {
-        log.info('Wohoo, Database is healthy');
-    }).catch(function (err) {
+        return knexMigrator.isDatabaseOK()
+            .then(function () {
+                log.info('Wohoo, Database is healthy');
+            });
+    })
+    .catch(function (err) {
         if (err.code === 'DB_NEEDS_MIGRATION') {
-           log.emergency('Migrations are missing. Please run knex-migrate migrate.');
+            log.emergency('Migrations are missing. Please run knex-migrate migrate.');
         } else if(err.code === 'MIGRATION_TABLE_IS_MISSING' || err.code === 'DB_NOT_INITIALISED') {
             log.emergency('Database was never initialised. Please run knex-migrate init.');
         } else {

--- a/bin/knex-migrator-init
+++ b/bin/knex-migrator-init
@@ -1,32 +1,36 @@
 #!/usr/bin/env node
 
-var KnexMigrator = require('../');
 var program = require('commander');
+var utils = require('../lib/utils');
 
 /**
  * @TODO: remove coloured-log (it can't print errors...)
  */
 var Log = require('coloured-log');
 var log = new Log(Log.INFO);
-var migrator;
+var knexMigrator;
 
-program
-    .option('--skip <item>')
-    .option('--only <item>')
-    .parse(process.argv);
+utils.getKnexMigrator({path: process.cwd()})
+    .then(function (KnexMigrator) {
+        program
+            .option('--skip <item>')
+            .option('--only <item>')
+            .parse(process.argv);
 
-try {
-    migrator = new KnexMigrator();
-} catch (err) {
-    log.error(err.message);
-    process.exit();
-}
+        try {
+            knexMigrator = new KnexMigrator();
+        } catch (err) {
+            log.error(err.message);
+            process.exit();
+        }
 
-return migrator.init({
-    skip: program.skip,
-    only: program.only
-}).then(function () {
-    log.info('Finished database init!');
-}).catch(function (err) {
-    log.error(err.message);
-});
+        return knexMigrator.init({
+            skip: program.skip,
+            only: program.only
+        }).then(function () {
+            log.info('Finished database init!');
+        });
+    })
+    .catch(function (err) {
+        log.error(err.message);
+    });

--- a/bin/knex-migrator-migrate
+++ b/bin/knex-migrator-migrate
@@ -1,32 +1,36 @@
 #!/usr/bin/env node
 
-var KnexMigrator = require('../');
 var program = require('commander');
+var utils = require('../lib/utils');
 
 /**
  * @TODO: remove coloured-log (it can't print errors...)
  */
 var Log = require('coloured-log');
 var log = new Log(Log.INFO);
-var migrator;
+var knexMigrator;
 
-program
-    .option('--v <item>')
-    .option('--only <item>')
-    .parse(process.argv);
+utils.getKnexMigrator({path: process.cwd()})
+    .then(function (KnexMigrator) {
+        program
+            .option('--v <item>')
+            .option('--only <item>')
+            .parse(process.argv);
 
-try {
-    migrator = new KnexMigrator();
-} catch (err) {
-    log.error(err.message);
-    process.exit();
-}
+        try {
+            knexMigrator = new KnexMigrator();
+        } catch (err) {
+            log.error(err.message);
+            process.exit();
+        }
 
-return migrator.migrate({
-    version: program.v,
-    only: program.only
-}).then(function () {
-    log.info('Finished database migration!');
-}).catch(function (err) {
-    log.error(err.message);
-});
+        return knexMigrator.migrate({
+            version: program.v,
+            only: program.only
+        }).then(function () {
+            log.info('Finished database migration!');
+        });
+    })
+    .catch(function (err) {
+        log.error(err.message);
+    });

--- a/bin/knex-migrator-reset
+++ b/bin/knex-migrator-reset
@@ -1,28 +1,32 @@
 #!/usr/bin/env node
 
-var KnexMigrator = require('../');
 var program = require('commander');
+var utils = require('../lib/utils');
 
 /**
  * @TODO: remove coloured-log (it can't print errors...)
  */
 var Log = require('coloured-log');
 var log = new Log(Log.INFO);
-var migrator;
+var knexMigrator;
 
-program
-    .parse(process.argv);
+utils.getKnexMigrator({path: process.cwd()})
+    .then(function (KnexMigrator) {
+        program
+            .parse(process.argv);
 
-try {
-    migrator = new KnexMigrator();
-} catch (err) {
-    log.error(err.message);
-    process.exit();
-}
+        try {
+            knexMigrator = new KnexMigrator();
+        } catch (err) {
+            log.error(err.message);
+            process.exit();
+        }
 
-return migrator.reset()
-    .then(function () {
-        log.info('Finished database reset!');
-    }).catch(function (err) {
+        return knexMigrator.reset()
+            .then(function () {
+                log.info('Finished database reset!');
+            });
+    })
+    .catch(function (err) {
         log.error(err.message);
     });

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,6 +1,8 @@
 var path = require('path'),
     _ = require('lodash'),
     fs = require('fs'),
+    Promise = require('bluebird'),
+    resolve = Promise.promisify(require('resolve')),
     debug = require('debug')('knex-migrator:utils'),
     errors = require('./errors');
 
@@ -55,4 +57,19 @@ exports.getPath = function getPath(options) {
 
     debug(migrationsPath);
     return migrationsPath;
+};
+
+/**
+ * auto detect local installation to avoid version incompatible behaviour
+ */
+exports.getKnexMigrator = function getKnexMigrator(options) {
+    options = options || {};
+
+    return resolve('knex-migrator', {basedir: options.path})
+        .then(function (localCLIPath) {
+            return require(localCLIPath);
+        })
+        .catch(function () {
+            return require('./');
+        });
 };

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "commander": "2.9.0",
     "debug": "2.2.0",
     "knex": "0.12.2",
-    "lodash": "4.16.4"
+    "lodash": "4.16.4",
+    "resolve": "1.1.7"
   },
   "files": [
     "bin",


### PR DESCRIPTION
To avoid version incompatible behaviour, we ensure using the local installation when running `knex-migrator` in the shell.

The basic idea is stolen from https://github.com/ember-cli/ember-cli/blob/master/bin/ember.
Thanks to @acburdine 