### PR TITLE
Escape db name in database creation

### DIFF
--- a/lib/database.js
+++ b/lib/database.js
@@ -51,7 +51,7 @@ exports.createDatabaseIfNotExist = function createDatabaseIfNotExist(dbConfig) {
         }
     });
 
-    return connection.raw('CREATE DATABASE ' + name + ' CHARACTER SET ' + charset + ';')
+    return connection.raw('CREATE DATABASE `' + name + '` CHARACTER SET ' + charset + ';')
         .catch(function (err) {
             // CASE: DB exists
             if (err.errno === 1007) {
@@ -89,7 +89,7 @@ exports.drop = function drop(options) {
 
     if (dbConfig.client === 'mysql') {
         debug('Drop database: ' + dbConfig.connection.database);
-        return connection.raw('DROP DATABASE ' + dbConfig.connection.database + ';')
+        return connection.raw('DROP DATABASE `' + dbConfig.connection.database + '`;')
             .catch(function (err) {
                 // CASE: database does not exist, skip
                 if (err.errno === 1049) {
@@ -127,7 +127,7 @@ exports.drop = function drop(options) {
     }
     else {
         return Promise.reject(new errors.KnexMigrateError({
-            message: 'Database client not support: ' + dbConfig.client
+            message: 'Database client not supported: ' + dbConfig.client
         }));
     }
 };


### PR DESCRIPTION
closes #22
- enclose database name in backtics (`) to escape any special characters
- add IF NOT EXISTS clause to db creation statement