### PR TITLE
🐛  return correct error codes when looking up the migrations table

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -444,15 +444,15 @@ KnexMigrator.prototype.integrityCheck = function integrityCheck(options) {
             if (err.errno === 1049) {
                 throw new errors.DatabaseIsNotOkError({
                     message: 'Please run knex-migrator init',
-                    code: 'MIGRATION_TABLE_IS_MISSING'
+                    code: 'DB_NOT_INITIALISED'
                 });
             }
 
-            // CASE: table does not exist
+            // CASE: migration table does not exist
             if (err.errno === 1 || err.errno === 1146) {
                 throw new errors.DatabaseIsNotOkError({
                     message: 'Please run knex-migrator init',
-                    code: 'DB_NOT_INITIALISED'
+                    code: 'MIGRATION_TABLE_IS_MISSING'
                 });
             }
 

--- a/test/functional_spec.js
+++ b/test/functional_spec.js
@@ -140,7 +140,7 @@ describe('Functional flow test', function () {
             .catch(function (err) {
                 should.exist(err);
                 (err instanceof errors.DatabaseIsNotOkError);
-                err.code.should.eql('DB_NOT_INITIALISED');
+                err.code.should.eql('MIGRATION_TABLE_IS_MISSING');
             });
     });
 


### PR DESCRIPTION
closes #45

- [x] test manual