### PR TITLE
Enable charset and timezone to be set via MigratorConfig.js

### DIFF
--- a/lib/database.js
+++ b/lib/database.js
@@ -21,8 +21,8 @@ exports.connect = function connect(options) {
     }
 
     if (client === 'mysql') {
-        options.connection.timezone = 'UTC';
-        options.connection.charset = 'utf8mb4';
+        options.connection.timezone = options.connection.timezone || 'UTC';
+        options.connection.charset = options.connection.charset || 'utf8mb4';
     }
 
     return knex(options);

--- a/lib/database.js
+++ b/lib/database.js
@@ -7,10 +7,6 @@ var knex = require('knex'),
 
 /**
  * we only support knex
- *
- * @TODO:
- * - encoding is hardcoded
- * - timezone is hardcoded
  */
 exports.connect = function connect(options) {
     options = options || {};


### PR DESCRIPTION
When passing through the normal knex connection parameters, the database.connection function now uses the values passed in and defaults to the hardcoded options. This allows greater flexibility of database charsets and timezones.