### PR TITLE
🎨  static logging properties

### DIFF
--- a/logging.js
+++ b/logging.js
@@ -1,10 +1,8 @@
-var config = require('ghost-ignition').config();
 var logging = require('ghost-ignition').logging;
 
 module.exports = logging({
-    env: config.get('env'),
-    path: config.get('logging:path'),
-    mode: config.get('logging:mode'),
-    level: config.get('logging:level'),
-    transports: config.get('logging:transports')
+    env: process.env.NODE_ENV,
+    mode: 'long',
+    level: 'info',
+    transports: ['stdout']
 });


### PR DESCRIPTION
refs https://github.com/TryGhost/Ignition/issues/3

- if using knex-migrator within the application, knex-migrator used the config file from the root directory
- this caused bunyan to create another pair of log files if file transport is defined
- make logging properties static, because logging is only useful when using the CLI
- and the CLI will always log to stdout for now