### PR TITLE
migrate --init, bug fixes and --mgpath option

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ knex-migrator init --only 1
 knex-migrator migrate [migrates your database to latest state, rolls back if an error happens]
 knex-migrator migrate --v 1.2
 knex-migrator migrate --v 1.2 --force [doesn't matter which current version you are on, we force executing the version]
+knex-migrator migrate --init [avoids running `init`, a combined command]
 
 knex-migrator reset [resets your database]
 ```

--- a/README.md
+++ b/README.md
@@ -54,11 +54,13 @@ knex-migrator health [shows the database health]
 knex-migrator init [initialises your database based on your init scripts]
 knex-migrator init --skip 1
 knex-migrator init --only 1
+knex-migrator init --mgpath <path-to-MigratorConfig.js>
 
 knex-migrator migrate [migrates your database to latest state, rolls back if an error happens]
 knex-migrator migrate --v 1.2
 knex-migrator migrate --v 1.2 --force [doesn't matter which current version you are on, we force executing the version]
 knex-migrator migrate --init [avoids running `init`, a combined command]
+knex-migrator migrate --init --mgpath <path-to-MigratorConfig.js>
 
 knex-migrator reset [resets your database]
 ```

--- a/bin/knex-migrator-health
+++ b/bin/knex-migrator-health
@@ -9,10 +9,11 @@ var knexMigrator;
 utils.getKnexMigrator({path: process.cwd()})
     .then(function (KnexMigrator) {
         program
+            .option('--mgpath <path>')
             .parse(process.argv);
 
         try {
-            knexMigrator = new KnexMigrator();
+            knexMigrator = new KnexMigrator({knexMigratorFilePath: program.mgpath});
         } catch (err) {
             logging.error(err);
             process.exit();

--- a/bin/knex-migrator-init
+++ b/bin/knex-migrator-init
@@ -11,10 +11,11 @@ utils.getKnexMigrator({path: process.cwd()})
         program
             .option('--skip <item>')
             .option('--only <item>')
+            .option('--mgpath <path>')
             .parse(process.argv);
 
         try {
-            knexMigrator = new KnexMigrator();
+            knexMigrator = new KnexMigrator({knexMigratorFilePath: program.mgpath});
         } catch (err) {
             logging.error(err);
             process.exit();

--- a/bin/knex-migrator-migrate
+++ b/bin/knex-migrator-migrate
@@ -12,6 +12,7 @@ utils.getKnexMigrator({path: process.cwd()})
             .option('--v <item>')
             .option('--only <item>')
             .option('--force')
+            .option('--init')
             .parse(process.argv);
 
         try {

--- a/bin/knex-migrator-migrate
+++ b/bin/knex-migrator-migrate
@@ -11,12 +11,13 @@ utils.getKnexMigrator({path: process.cwd()})
         program
             .option('--v <item>')
             .option('--only <item>')
+            .option('--mgpath <path>')
             .option('--force')
             .option('--init')
             .parse(process.argv);
 
         try {
-            knexMigrator = new KnexMigrator();
+            knexMigrator = new KnexMigrator({knexMigratorFilePath: program.mgpath});
         } catch (err) {
             logging.error(err);
             process.exit();
@@ -25,7 +26,8 @@ utils.getKnexMigrator({path: process.cwd()})
         return knexMigrator.migrate({
             version: program.v,
             only: program.only,
-            force: program.force
+            force: program.force,
+            init: program.init
         }).then(function () {
             logging.info('Finished database migration!');
         });

--- a/bin/knex-migrator-reset
+++ b/bin/knex-migrator-reset
@@ -9,10 +9,11 @@ var knexMigrator;
 utils.getKnexMigrator({path: process.cwd()})
     .then(function (KnexMigrator) {
         program
+            .option('--mgpath <path>')
             .parse(process.argv);
 
         try {
-            knexMigrator = new KnexMigrator();
+            knexMigrator = new KnexMigrator({knexMigratorFilePath: program.mgpath});
         } catch (err) {
             logging.error(err);
             process.exit();

--- a/lib/index.js
+++ b/lib/index.js
@@ -127,6 +127,7 @@ KnexMigrator.prototype.init = function init(options) {
  * knex-migrator migrate --v v1.1 --force
  * knex-migrator migrate --v v1.1 --only 2
  * knex-migrator migrate --v v1.1 --skip 3
+ * knex-migrator migrate --init
  *
  * Not Allowed:
  * knex-migrator migrate --skip 3
@@ -134,7 +135,7 @@ KnexMigrator.prototype.init = function init(options) {
  * By default: migrate will auto detect
  *
  * @TODO:
- *   - create more functions
+ *   - create more functions :P
  */
 KnexMigrator.prototype.migrate = function migrate(options) {
     options = options || {};
@@ -142,6 +143,7 @@ KnexMigrator.prototype.migrate = function migrate(options) {
         onlyVersion = options.version,
         onlyFile = options.only,
         force = options.force,
+        init = options.init,
         hooks = {};
 
     if (onlyFile && !onlyVersion) {
@@ -150,6 +152,13 @@ KnexMigrator.prototype.migrate = function migrate(options) {
 
     if (onlyVersion) {
         debug('onlyVersion: ' + onlyVersion);
+    }
+
+    if (init) {
+        return this.init()
+            .then(function () {
+                return self.migrate(_.omit(options, 'init'));
+            });
     }
 
     try {

--- a/lib/index.js
+++ b/lib/index.js
@@ -14,7 +14,7 @@ function KnexMigrator(options) {
         knexMigratorFilePath = options.knexMigratorFilePath || process.cwd();
 
     try {
-        config = require(path.join(knexMigratorFilePath, '/MigratorConfig.js'));
+        config = require(path.join(path.resolve(knexMigratorFilePath), '/MigratorConfig.js'));
     } catch (err) {
         if (err.code === 'MODULE_NOT_FOUND') {
             throw new errors.KnexMigrateError({

--- a/lib/index.js
+++ b/lib/index.js
@@ -184,11 +184,13 @@ KnexMigrator.prototype.migrate = function migrate(options) {
                 }
             });
 
-            if (!_.find(result, function (obj, key) {
-                    return key === onlyVersion;
-                })) {
+            if (onlyVersion) {
+                if (!_.find(result, function (obj, key) {
+                        return key === onlyVersion;
+                    })) {
 
-                logging.warn('Cannot find requested version: ' + onlyVersion);
+                    logging.warn('Cannot find requested version: ' + onlyVersion);
+                }
             }
 
             _.each(result, function (value, version) {


### PR DESCRIPTION
no issue

This PR is reasoned by a use case for our [CLI](https://github.com/TryGhost/Ghost-CLI) tool.
It adds a new option to the migrate command. By this the CLI does not have to run two shell commands (init and migrate). The error handling via the shell is harder than pragmatically.

- [x] a real test

e.g.
`NODE_ENV=production knex-migrator migrate --init --mgpath current/`
