### PR TITLE
🐛  Fix future migration versions

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -459,7 +459,8 @@ KnexMigrator.prototype.integrityCheck = function integrityCheck(options) {
         folders = [],
         currentVersionInitTask,
         operations = {},
-        toReturn = {};
+        toReturn = {},
+        futureVersions = [];
 
     // CASE: we always fetch the init scripts and check them
     // 1. to be able to add more init scripts
@@ -474,7 +475,6 @@ KnexMigrator.prototype.integrityCheck = function integrityCheck(options) {
     }
 
     _.each(folders, function (folder) {
-
         // CASE: versions/1.1-members or versions/2.0-payments
         if (folder !== 'init') {
             try {
@@ -487,14 +487,11 @@ KnexMigrator.prototype.integrityCheck = function integrityCheck(options) {
         }
 
         // CASE:
-        // if you current version if 1.0 and you add migration scripts for the next version 1.1
-        // we won't execute them until your current version changes to 1.1
+        // if your current version is 1.0 and you add migration scripts for the next version 1.1
+        // we won't execute them until your current version changes to 1.1 or until you force KM to migrate to it
         if (self.currentVersion && !force) {
             if (utils.isGreaterThanVersion({smallerVersion: self.currentVersion, greaterVersion: folder})) {
-                logging.warn('Skip: ' + folder);
-                logging.warn('Current version in MigratorConfig.js is smaller then requested version, use --force to proceed!');
-                logging.warn('Use --force to proceed!');
-                return;
+                futureVersions.push(folder);
             }
         }
 
@@ -558,6 +555,19 @@ KnexMigrator.prototype.integrityCheck = function integrityCheck(options) {
                     actual: actual
                 }
             });
+
+
+            // CASE: ensure that either you have to run `migrate --force` or they ran already
+            if (futureVersions.length) {
+                _.each(futureVersions, function (futureVersion) {
+                    if (toReturn[futureVersion].actual !== toReturn[futureVersion].expected) {
+                        logging.warn('knex-migrator is skipping ' + futureVersion);
+                        logging.warn('Current version in MigratorConfig.js is smaller then requested version, use --force to proceed!');
+                        logging.warn('Please run `knex-migrator migrate --v ' + futureVersion + ' --force` to proceed!');
+                        delete toReturn[futureVersion];
+                    }
+                });
+            }
 
             return toReturn;
         });


### PR DESCRIPTION
no issue

- add a clearer warning message
- if you force running a future migration version, knex-migrator detects that now and doesn't show the warning