### PR TITLE
DB connection configuration as connection string

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,7 +1,8 @@
 {
   "env": {
     "node": true,
-    "es6": true
+    "es6": true,
+    "mocha": true
   },
   "extends": "eslint:recommended",
   "globals": {},

--- a/lib/database-configuration.js
+++ b/lib/database-configuration.js
@@ -1,0 +1,88 @@
+var url = require('url'),
+    _ = require('lodash/lodash'),
+    errors = require('./errors');
+
+var queryStringToObject = function (queryString) {
+    var params = {};
+    var queryParams = queryString.split('&');
+
+    var paramKeyValue;
+    for (var i = 0, ln = queryParams.length; i < ln; i++) {
+        paramKeyValue = queryParams[i].split('=');
+        params[paramKeyValue[0]] = paramKeyValue[1];
+    }
+
+    return params;
+}
+
+var handleMySQL = function (urlObject) {
+    var auth = [];
+    if (urlObject.auth) {
+        auth = urlObject.auth.split(':');
+    }
+
+    var connectionObject = {
+        host: urlObject.hostname,
+        user: auth[0],
+        password: auth[1],
+        database: urlObject.pathname.substr(1)
+    };
+
+    if (null !== urlObject.port) {
+        connectionObject.port = urlObject.port;
+    }
+
+    if (null === urlObject.query) {
+        return connectionObject;
+    }
+
+    var queryObject = queryStringToObject(urlObject.query);
+
+    if (undefined !== queryObject.characterEncoding) {
+        connectionObject.charset = queryObject.characterEncoding;
+    }
+
+    return connectionObject;
+}
+
+var handleSQLite = function (urlObject) {
+    var cleanedName = urlObject.pathname.replace(/^\/\/\//, '/')
+    return {
+        filename: cleanedName
+    }
+}
+
+var parseDbString = function (str) {
+    var parsedUrl = url.parse(str);
+    switch (parsedUrl.protocol) {
+        case 'mysql:':
+            return handleMySQL(parsedUrl);
+            break;
+
+        case 'sqlite:':
+        case 'sqlite3:':
+            return handleSQLite(parsedUrl);
+            break;
+
+        default:
+            throw new errors.KnexMigrateError({
+                code: 'DATABASE_PROTOCOL_UNSUPPORTED'
+            })
+                ;
+    }
+}
+
+exports.ensureObject = function (databaseConfig) {
+    if (_.isObject(databaseConfig.connection)) {
+        return databaseConfig;
+    }
+
+    if (_.isString(databaseConfig.connection)) {
+        databaseConfig.connection = parseDbString(databaseConfig.connection);
+        return databaseConfig;
+    }
+
+    throw new errors.KnexMigrateError({
+        code: 'DATABASE_CONNECTION_FORMAT_UNSUPPORTED'
+    })
+}

--- a/lib/database-configuration.js
+++ b/lib/database-configuration.js
@@ -1,76 +1,75 @@
-var url = require('url'),
+'use strict';
+
+const url = require('url'),
     _ = require('lodash/lodash'),
     errors = require('./errors');
 
-var queryStringToObject = function (queryString) {
-    var params = {};
-    var queryParams = queryString.split('&');
+const queryStringToObject = function (queryString) {
+    const params = {};
+    const queryParams = queryString.split('&');
 
-    var paramKeyValue;
-    for (var i = 0, ln = queryParams.length; i < ln; i++) {
+    let paramKeyValue;
+    for (let i = 0, ln = queryParams.length; i < ln; i = i + 1) {
         paramKeyValue = queryParams[i].split('=');
         params[paramKeyValue[0]] = paramKeyValue[1];
     }
 
     return params;
-}
+};
 
-var handleMySQL = function (urlObject) {
-    var auth = [];
+const handleMySQL = function (urlObject) {
+    let auth = [];
     if (urlObject.auth) {
         auth = urlObject.auth.split(':');
     }
 
-    var connectionObject = {
+    const connectionObject = {
         host: urlObject.hostname,
         user: auth[0],
         password: auth[1],
         database: urlObject.pathname.substr(1)
     };
 
-    if (null !== urlObject.port) {
+    if (urlObject.port !== null) {
         connectionObject.port = urlObject.port;
     }
 
-    if (null === urlObject.query) {
+    if (urlObject.query === null) {
         return connectionObject;
     }
 
-    var queryObject = queryStringToObject(urlObject.query);
+    const queryObject = queryStringToObject(urlObject.query);
 
     if (undefined !== queryObject.characterEncoding) {
         connectionObject.charset = queryObject.characterEncoding;
     }
 
     return connectionObject;
-}
+};
 
-var handleSQLite = function (urlObject) {
-    var cleanedName = urlObject.pathname.replace(/^\/\/\//, '/')
+const handleSQLite = function (urlObject) {
+    const cleanedName = urlObject.pathname.replace(/^\/\/\//, '/');
     return {
         filename: cleanedName
     }
-}
+};
 
-var parseDbString = function (str) {
-    var parsedUrl = url.parse(str);
+const parseDbString = function (str) {
+    const parsedUrl = url.parse(str);
     switch (parsedUrl.protocol) {
         case 'mysql:':
             return handleMySQL(parsedUrl);
-            break;
 
         case 'sqlite:':
         case 'sqlite3:':
             return handleSQLite(parsedUrl);
-            break;
 
         default:
             throw new errors.KnexMigrateError({
                 code: 'DATABASE_PROTOCOL_UNSUPPORTED'
-            })
-                ;
+            });
     }
-}
+};
 
 exports.ensureObject = function (databaseConfig) {
     if (_.isObject(databaseConfig.connection)) {
@@ -85,4 +84,4 @@ exports.ensureObject = function (databaseConfig) {
     throw new errors.KnexMigrateError({
         code: 'DATABASE_CONNECTION_FORMAT_UNSUPPORTED'
     })
-}
+};

--- a/lib/index.js
+++ b/lib/index.js
@@ -8,7 +8,7 @@ const database = require('./database');
 const utils = require('./utils');
 const errors = require('./errors');
 const logging = require('../logging');
-var dbConfig = require('./database-configuration');
+const dbConfig = require('./database-configuration');
 
 function KnexMigrator(options) {
     options = options || {};

--- a/lib/index.js
+++ b/lib/index.js
@@ -8,6 +8,7 @@ const database = require('./database');
 const utils = require('./utils');
 const errors = require('./errors');
 const logging = require('../logging');
+var dbConfig = require('./database-configuration');
 
 function KnexMigrator(options) {
     options = options || {};
@@ -45,7 +46,7 @@ function KnexMigrator(options) {
     this.subfolder = config.subfolder || 'versions';
 
     // @TODO: make test connection to database to ensure database credentials are OK
-    this.dbConfig = config.database;
+    this.dbConfig = dbConfig.ensureObject(config.database);
 
     // @TODO: create dialect hooks
     this.isMySQL = this.dbConfig.client === 'mysql';

--- a/test/database-config_spec.js
+++ b/test/database-config_spec.js
@@ -1,13 +1,13 @@
-var config = require('../lib/database-configuration'),
+'use strict';
+
+const config = require('../lib/database-configuration'),
     should = require('should');
 
 
 describe('Database Configuration', function () {
-
     describe('ensureObject', function () {
         it('doesn\'t modify the connection object if it\'s not a string', function () {
-
-            var testObject = {
+            const testObject = {
                 connection: {
                     host: '127.0.0.1',
                     user: 'user',
@@ -17,17 +17,17 @@ describe('Database Configuration', function () {
                 }
             };
 
-            var resultObject = config.ensureObject(testObject);
+            const resultObject = config.ensureObject(testObject);
 
             should(resultObject).be.deepEqual(testObject);
         });
 
         it('converts a mysql connection string to a connection object', function () {
-            var testObject = {
+            const testObject = {
                 connection: 'mysql://user:password@127.0.0.1:12345/ghost'
-            }
+            };
 
-            var resultObject = config.ensureObject(testObject);
+            const resultObject = config.ensureObject(testObject);
 
             should(resultObject.connection).be.deepEqual({
                 host: '127.0.0.1',
@@ -39,11 +39,11 @@ describe('Database Configuration', function () {
         });
 
         it('converts a mysql connection string to a connection object with an optional port', function () {
-            var testObject = {
+            const testObject = {
                 connection: 'mysql://user:password@127.0.0.1/ghost'
-            }
+            };
 
-            var resultObject = config.ensureObject(testObject);
+            const resultObject = config.ensureObject(testObject);
 
             should(resultObject.connection).be.deepEqual({
                 host: '127.0.0.1',
@@ -54,11 +54,11 @@ describe('Database Configuration', function () {
         });
 
         it('converts a mysql connection string with the charset defined to a connection object', function () {
-            var testObject = {
+            const testObject = {
                 connection: 'mysql://user:password@127.0.0.1:12345/ghost?characterEncoding=utf8'
-            }
+            };
 
-            var resultObject = config.ensureObject(testObject);
+            const resultObject = config.ensureObject(testObject);
 
             should(resultObject.connection).be.deepEqual({
                 host: '127.0.0.1',
@@ -71,38 +71,38 @@ describe('Database Configuration', function () {
         });
 
         it('converts a sqlite connection string', function () {
-            var testObject = {
+            const testObject = {
                 connection: 'sqlite:file:/home/user/database.db'
-            }
+            };
 
-            var resultObject = config.ensureObject(testObject);
+            const resultObject = config.ensureObject(testObject);
 
             should(resultObject.connection).be.deepEqual({
-                filename: "/home/user/database.db"
+                filename: '/home/user/database.db'
             });
         });
 
         it('converts a sqlite connection string on windows', function () {
-            var testObject = {
+            const testObject = {
                 connection: 'sqlite:file:///C:/Documents%20and%20Settings/user/Desktop/database.db'
-            }
+            };
 
-            var resultObject = config.ensureObject(testObject);
+            const resultObject = config.ensureObject(testObject);
 
             should(resultObject.connection).be.deepEqual({
-                filename: "/C:/Documents%20and%20Settings/user/Desktop/database.db"
+                filename: '/C:/Documents%20and%20Settings/user/Desktop/database.db'
             });
         });
 
         it('converts a sqlite connection string with the file protocol omitted', function () {
-            var testObject = {
+            const testObject = {
                 connection: 'sqlite:/home/user/database.db'
-            }
+            };
 
-            var resultObject = config.ensureObject(testObject);
+            const resultObject = config.ensureObject(testObject);
 
             should(resultObject.connection).be.deepEqual({
-                filename: "/home/user/database.db"
+                filename: '/home/user/database.db'
             });
         });
     });

--- a/test/database-config_spec.js
+++ b/test/database-config_spec.js
@@ -1,0 +1,109 @@
+var config = require('../lib/database-configuration'),
+    should = require('should');
+
+
+describe('Database Configuration', function () {
+
+    describe('ensureObject', function () {
+        it('doesn\'t modify the connection object if it\'s not a string', function () {
+
+            var testObject = {
+                connection: {
+                    host: '127.0.0.1',
+                    user: 'user',
+                    password: 'password',
+                    charset: 'utf8',
+                    database: 'ghost'
+                }
+            };
+
+            var resultObject = config.ensureObject(testObject);
+
+            should(resultObject).be.deepEqual(testObject);
+        });
+
+        it('converts a mysql connection string to a connection object', function () {
+            var testObject = {
+                connection: 'mysql://user:password@127.0.0.1:12345/ghost'
+            }
+
+            var resultObject = config.ensureObject(testObject);
+
+            should(resultObject.connection).be.deepEqual({
+                host: '127.0.0.1',
+                user: 'user',
+                password: 'password',
+                port: '12345',
+                database: 'ghost'
+            });
+        });
+
+        it('converts a mysql connection string to a connection object with an optional port', function () {
+            var testObject = {
+                connection: 'mysql://user:password@127.0.0.1/ghost'
+            }
+
+            var resultObject = config.ensureObject(testObject);
+
+            should(resultObject.connection).be.deepEqual({
+                host: '127.0.0.1',
+                user: 'user',
+                password: 'password',
+                database: 'ghost'
+            });
+        });
+
+        it('converts a mysql connection string with the charset defined to a connection object', function () {
+            var testObject = {
+                connection: 'mysql://user:password@127.0.0.1:12345/ghost?characterEncoding=utf8'
+            }
+
+            var resultObject = config.ensureObject(testObject);
+
+            should(resultObject.connection).be.deepEqual({
+                host: '127.0.0.1',
+                user: 'user',
+                password: 'password',
+                charset: 'utf8',
+                port: '12345',
+                database: 'ghost'
+            });
+        });
+
+        it('converts a sqlite connection string', function () {
+            var testObject = {
+                connection: 'sqlite:file:/home/user/database.db'
+            }
+
+            var resultObject = config.ensureObject(testObject);
+
+            should(resultObject.connection).be.deepEqual({
+                filename: "/home/user/database.db"
+            });
+        });
+
+        it('converts a sqlite connection string on windows', function () {
+            var testObject = {
+                connection: 'sqlite:file:///C:/Documents%20and%20Settings/user/Desktop/database.db'
+            }
+
+            var resultObject = config.ensureObject(testObject);
+
+            should(resultObject.connection).be.deepEqual({
+                filename: "/C:/Documents%20and%20Settings/user/Desktop/database.db"
+            });
+        });
+
+        it('converts a sqlite connection string with the file protocol omitted', function () {
+            var testObject = {
+                connection: 'sqlite:/home/user/database.db'
+            }
+
+            var resultObject = config.ensureObject(testObject);
+
+            should(resultObject.connection).be.deepEqual({
+                filename: "/home/user/database.db"
+            });
+        });
+    });
+});


### PR DESCRIPTION
Hello,

In one of my project, the only way to setup the database configuration is to use a database connection string like `mysql://user:password@mysql.dev:12345/ghost`

To run this project have written some kind of hack to configure Ghost and Knex Migrator. This PR is the fix I need to remove that hack from Knex Migrator.

Since I didn't found Coding Standards for this repo, please let me know if you have suggestions on how to improve the code.

Have a good day,
he8us