### PR TITLE
Add error handling for duplicate migrations

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -644,10 +644,17 @@ KnexMigrator.prototype.isDatabaseOK = function isDatabaseOK(options) {
         }
 
         _.each(_.omit(result, 'init'), function (value) {
-            if (value.expected !== value.actual) {
+            // CASE: there are more migrations expected than have been run, database needs to be migrated
+            if (value.expected > value.actual) {
                 throw new errors.DatabaseIsNotOkError({
                     message: 'Migrations are missing. Please run knex-migrator migrate.',
                     code: 'DB_NEEDS_MIGRATION'
+                });
+            // CASE: there are more actual migrations than expected, something has gone wrong :(
+            } else if (value.expected < value.actual) {
+                throw new errors.DatabaseIsNotOkError({
+                    message: 'Detected more items in the migrations table than expected. Please manually inspect the migrations table.',
+                    code: 'MIGRATION_STATE_ERROR'
                 });
             }
         });


### PR DESCRIPTION
This is a small change to ensure that the error code "DB_NEEDS_MIGRATION" isn't thrown when there are too many migrations already.

This can cause us to retry migrations, when actually a manual fix is required.

This doesn't do anything to resolve the problem of duplicates occurring in the first place.

refs #76 

- If there are more actual migrations than expected migrations, throw a different error
- This prevents us from showing "Migrations are missing" when the DB health check fails due
 to duplicate / too many migrations