### PR TITLE
Make it possible to run tests with a different database e.g. MySQL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,9 @@ package-lock.json
 
 # IDE
 .idea/*
+
+# database
+test.db
+
+# config
+config.testing-mysql.json

--- a/README.md
+++ b/README.md
@@ -4,6 +4,12 @@ DB migration tool for knex
 ## install
 ```npm install -g knex-migrator --save```
 
+## testing
+
+`npm test`
+
+By default, knex-migrator tests with Sqlite3 (local & travis).
+If you would like to test MySQL, simply add a config file and use the `NODE_ENV` parameter.
 
 ## important facts
 If you are using `mysql`, `knex-migrator` is able to create the database for you.

--- a/config.testing.json
+++ b/config.testing.json
@@ -1,0 +1,9 @@
+{
+    "database": {
+        "client": "sqlite3",
+        "connection": {
+            "filename": "test.db"
+        },
+        "useNullAsDefault": true
+    }
+}

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "license": "MIT",
   "scripts": {
     "lint": "eslint bin lib",
-    "test": "npm run lint && LEVEL=fatal _mocha --report lcovonly -- test/*_spec.js"
+    "test": "npm run lint && LEVEL=fatal _mocha --require test/utils.js --report lcovonly -- test/*_spec.js"
   },
   "bin": {
     "knex-migrator": "./bin/knex-migrator",

--- a/test/utils.js
+++ b/test/utils.js
@@ -1,0 +1,26 @@
+'use strict';
+
+// DEFAULT env is sqlite3
+if (!process.env.NODE_ENV) {
+    process.env.NODE_ENV = 'testing';
+}
+
+const knex = require('knex');
+const fs = require('fs');
+const config = require('ghost-ignition').config();
+
+exports.connect = function () {
+    return knex(config.get('database'));
+};
+
+exports.writeMigratorConfig = function writeMigratorConfig(options) {
+    options = options || {};
+
+    let migratorConfig = {
+        database: config.get('database'),
+        migrationPath: options.migrationPath,
+        currentVersion: options.currentVersion
+    };
+
+    fs.writeFileSync(options.migratorConfigPath, 'module.exports = ' + JSON.stringify(migratorConfig) + ';', 'utf-8');
+};


### PR DESCRIPTION
no issue

- sqlite3 stays default for now
- be able to run `NODE_ENV=testing-mysql npm test`
- @TODO: run tests with MySQL in Travis by default