### PR TITLE
Add support for specifying the config via options

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,8 @@ knex-migrator rollback
 var KnexMigrator = require('knex-migrator');
 var knexMigrator = new KnexMigrator({
     knexMigratorFilePath: 'path-to-migrator-config-file' [optional]
+    // or
+    knexMigratorConfig: { ... } [optional]
 });
 
 // check your database health

--- a/lib/index.js
+++ b/lib/index.js
@@ -13,21 +13,7 @@ const logging = require('../logging');
 function KnexMigrator(options) {
     options = options || {};
 
-    let knexMigratorFilePath = options.knexMigratorFilePath || process.cwd(),
-        config;
-
-    try {
-        config = require(path.join(path.resolve(knexMigratorFilePath), '/MigratorConfig.js'));
-    } catch (err) {
-        if (err.code === 'MODULE_NOT_FOUND') {
-            throw new errors.KnexMigrateError({
-                message: 'Please provide a file named MigratorConfig.js in your project root.',
-                help: 'Read through the README.md to see which values are expected.'
-            });
-        }
-
-        throw new errors.KnexMigrateError({err: err});
-    }
+    let config = this._loadConfig(options);
 
     if (!config.database) {
         throw new Error('MigratorConfig.js needs to export a database config.');
@@ -50,6 +36,26 @@ function KnexMigrator(options) {
 
     // @TODO: create dialect hooks
     this.isMySQL = this.dbConfig.client === 'mysql';
+}
+
+KnexMigrator.prototype._loadConfig = function _loadConfig(options) {
+    if (options.knexMigratorConfig) {
+        return options.knexMigratorConfig;
+    }
+
+    let knexMigratorFilePath = options.knexMigratorFilePath || process.cwd();
+    try {
+        return require(path.join(path.resolve(knexMigratorFilePath), '/MigratorConfig.js'));
+    } catch (err) {
+        if (err.code === 'MODULE_NOT_FOUND') {
+            throw new errors.KnexMigrateError({
+                message: 'Please provide a file named MigratorConfig.js in your project root.',
+                help: 'Read through the README.md to see which values are expected.'
+            });
+        }
+
+        throw new errors.KnexMigrateError({err: err});
+    }
 }
 
 /**


### PR DESCRIPTION
**In short** <br> This adds the new `knexMigratorConfig` field into the JS API:

```js
const knexMigrator = new KnexMigrator({
    knexMigratorConfig: {
        database: {...},
        migrationPath: '',
        currentVersion: '',
        subfolder: '',
    },
});
```

When present, this field takes the precedence over `knexMigratorFilePath`.

**Reasoning** <br> I use knex-migrator from JS to initialize different Ghost DBs on runtime:

```js
const fillDbWithData = async (dbName, username, password) => {
    process.env.database__client = 'mysql';
    process.env.database__connection__host = process.env.DB_HOST;
    process.env.database__connection__user = username;
    process.env.database__connection__password = password;
    process.env.database__connection__database = dbName;

    const knexMigrator = new KnexMigrator({
        knexMigratorFilePath: path.resolve(
            require.resolve('ghost/package.json'),
            '..',
        ),
    });
    await knexMigrator.init();
};
```

However, with the current API, I’m unable to change the DB once I run the initial migration. As soon as knex-migrator requires Ghost’s `MigratorConfig.js`, this file remains cached, and I’m unable to change its `database` property.

With `knexMigratorConfig`, I could specify the config inline. This lets me to initialize the migrator with different options each time I create it:

```js
const fillDbWithData = async (dbName, username, password) => {
    const knexMigrator = new KnexMigrator({
        knexMigratorConfig: {
            ...require('ghost/MigratorConfig.js'),
            database: {
                client: 'mysql',
                connection: {
                    host: process.env.DB_HOST,
                    user: username,
                    password: password,
                    database: dbName,
                },
            },
        },
    });

    await knexMigrator.init();
};
```
