### PR TITLE
Correct version number comparison

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -3,6 +3,7 @@
 const path = require('path'),
     _ = require('lodash'),
     fs = require('fs'),
+    compareVer = require('compare-ver'),
     Promise = require('bluebird'),
     resolve = Promise.promisify(require('resolve')),
     debug = require('debug')('knex-migrator:utils'),
@@ -122,8 +123,16 @@ exports.isGreaterThanVersion = function isGreaterThanVersion(options) {
     let greaterVersion = options.greaterVersion;
     let smallerVersion = options.smallerVersion;
 
-    greaterVersion = Number(greaterVersion.toString().replace(/\./g, ''));
-    smallerVersion = Number(smallerVersion.toString().replace(/\./g, ''));
+    // Are they semver like strings?
+    const periodCheckRegex = new RegExp(/\./g);
+    if (periodCheckRegex.test(greaterVersion) && periodCheckRegex.test(smallerVersion)) {
+        // -1 less than, 0 equal, 1 greater than
+        return compareVer.gt(greaterVersion, smallerVersion) === 1;
+    }
+
+    // Must be numbers / number like strings
+    greaterVersion = Number(greaterVersion.toString());
+    smallerVersion = Number(smallerVersion.toString());
 
     return greaterVersion > smallerVersion;
 };

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
   "dependencies": {
     "bluebird": "^3.4.6",
     "commander": "2.9.0",
+    "compare-ver": "^2.0.2",
     "debug": "^2.2.0",
     "ghost-ignition": "^2.8.16",
     "knex": "^0.14.2",

--- a/test/utils_spec.js
+++ b/test/utils_spec.js
@@ -75,6 +75,20 @@ describe('Utils', function () {
                 greaterVersion: '1.0.0',
                 smallerVersion: '2.0.0'
             }).should.eql(false);
+
+            utils
+            .isGreaterThanVersion({
+                greaterVersion: "2.0.0",
+                smallerVersion: "1.0.10"
+            })
+            .should.eql(true);
+
+            utils
+            .isGreaterThanVersion({
+                greaterVersion: "1.10.0",
+                smallerVersion: "1.2.0"
+            })
+            .should.eql(true);
         });
 
         it('version has this notation: 1', function () {


### PR DESCRIPTION
The utils function isGreaterThanVersion was causing the following case:
1.10.0 would be classified as greater than 2.0.0. This was because
both would be stripped of their full stops (periods) and converted into
numbers. Resulting in a comparison of 1100 (1.10.0) against 200.

The compare-ver library has been introduced to handle semver like
comparisons.

Closes #97 