### PR TITLE
Optimised rollback task

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -250,6 +250,7 @@ KnexMigrator.prototype._rollback = function _rollback(options) {
     let version = options.version;
     let skippedTasks = options.skippedTasks || [];
     let onlyTasks = options.onlyTasks || [];
+    const failedTask = options.task;
     let tasks = [];
     let self = this;
 
@@ -265,6 +266,37 @@ KnexMigrator.prototype._rollback = function _rollback(options) {
                 throw err;
             }
         }
+    }
+
+    // CASE: rollback failed in one of the tasks
+    // CASE: if no task available, you are about to rollback manually `knex-migrator rollback`
+    if (failedTask) {
+        const newTasks = [];
+
+        for (let i = 0; i < tasks.length; i = i + 1) {
+            const task = tasks[i];
+
+            if (task.name !== failedTask.name) {
+                newTasks.push(task);
+            } else if (task.name === failedTask.name) {
+                /**
+                 * @NOTE
+                 *
+                 * The task, which has failed, is never written to the database.
+                 * But we have to double check if the target task was running in a transaction.
+                 *
+                 * Transaction: no need to rollback this task
+                 * No Transaction: we have to rollback this task, because of implicit commits
+                 */
+                if (!failedTask.config || !failedTask.config.transaction) {
+                    newTasks.push(task);
+                }
+
+                break;
+            }
+        }
+
+        tasks = newTasks;
     }
 
     tasks.reverse();
@@ -445,11 +477,15 @@ KnexMigrator.prototype.migrate = function migrate(options) {
                 throw err;
             }
 
-            debug('Rolling back: ' + err.message);
+            if (err.context && err.context.name) {
+                debug(`Task failed: ${err.context.name}`);
+            }
+
+            debug(`Rolling back: ${err.message}`);
 
             versionsToMigrate.reverse();
             return Promise.each(versionsToMigrate, function (version) {
-                return self._rollback({version: version});
+                return self._rollback({version: version, task: err.context});
             }).then(function () {
                 throw err;
             }).catch(function (innerErr) {
@@ -600,6 +636,7 @@ KnexMigrator.prototype.migrateTo = function migrateTo(options) {
             throw new errors.MigrationScriptError({
                 message: err.message,
                 help: 'Error occurred while executing the following migration: ' + task.name,
+                context: task,
                 err: err
             });
         });

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
   "license": "MIT",
   "scripts": {
     "lint": "eslint bin lib",
-    "test": "yarn lint && LEVEL=fatal _mocha --require test/utils.js --report lcovonly -- test/*_spec.js",
+    "test": "yarn lint && LEVEL=fatal _mocha --require test/utils.js --report lcovonly -- test/**/*_spec.js",
+    "test:unit": "yarn lint && LEVEL=fatal _mocha --require test/utils.js --report lcovonly -- test/unit/*_spec.js",
     "posttest": "yarn lint",
     "coverage": "nyc --reporter=lcov _mocha --require test/utils.js -- test/*_spec.js",
     "preship": "yarn test",

--- a/test/functional/database_spec.js
+++ b/test/functional/database_spec.js
@@ -1,5 +1,5 @@
-const database = require('../lib/database'),
-    errors = require('../lib/errors'),
+const database = require('../../lib/database'),
+    errors = require('../../lib/errors'),
     fs = require('fs');
 
 describe('Database', function () {

--- a/test/functional/functional_spec.js
+++ b/test/functional/functional_spec.js
@@ -1,13 +1,12 @@
 const _ = require('lodash'),
     path = require('path'),
-    knex = require('knex'),
     sinon = require('sinon'),
     should = require('should'),
     fs = require('fs'),
-    KnexMigrator = require('../lib'),
-    config = require('../config'),
-    errors = require('../lib/errors'),
-    testUtils = require('./utils');
+    KnexMigrator = require('../../lib'),
+    config = require('../../config'),
+    errors = require('../../lib/errors'),
+    testUtils = require('../utils');
 
 const sandbox = sinon.createSandbox(),
     _private = {};
@@ -24,20 +23,21 @@ _.each(['default', 'migrateInit'], function (initMethod) {
     describe('Functional flow: ' + initMethod, function () {
         this.timeout(1000 * 10);
 
-        var knexMigrator,
-            migrationPath = path.join(__dirname, 'assets', 'migrations'),
-            migrationsv11 = __dirname + '/assets/migrations/versions/1.1',
-            migrationsv12 = __dirname + '/assets/migrations/versions/1.2',
-            migrationsv13 = __dirname + '/assets/migrations/versions/1.3',
-            migrationsv14 = __dirname + '/assets/migrations/versions/1.4',
-            migrationsv15 = __dirname + '/assets/migrations/versions/1.5',
-            migrationsv11File = __dirname + '/assets/migrations/versions/1.1/1-modify-user.js',
-            migrationsv12File = __dirname + '/assets/migrations/versions/1.2/1-modify-user-again.js',
-            migrationsv13File = __dirname + '/assets/migrations/versions/1.3/1-delete-user.js',
-            migrationsv14File1 = __dirname + '/assets/migrations/versions/1.4/1-no-error.js',
-            migrationsv14File2 = __dirname + '/assets/migrations/versions/1.4/2-error.js',
-            migrationsv15File1 = __dirname + '/assets/migrations/versions/1.5/1-no-error.js',
-            migratorConfigPath = __dirname + '/assets/MigratorConfig.js',
+        let knexMigrator,
+            basePath = path.join(__dirname, '..', 'assets', 'migrations'),
+            migrationPath = basePath,
+            migrationsv11 = path.join(basePath, 'versions', '1.1'),
+            migrationsv12 = path.join(basePath, 'versions', '1.2'),
+            migrationsv13 = path.join(basePath, 'versions', '1.3'),
+            migrationsv14 = path.join(basePath, 'versions', '1.4'),
+            migrationsv15 = path.join(basePath, 'versions', '1.5'),
+            migrationsv11File = path.join(basePath, 'versions', '1.1', '1-modify-user.js'),
+            migrationsv12File = path.join(basePath, 'versions', '1.2', '1-modify-user-again.js'),
+            migrationsv13File = path.join(basePath, 'versions', '1.3', '1-delete-user.js'),
+            migrationsv14File1 = path.join(basePath, 'versions', '1.4', '1-no-error.js'),
+            migrationsv14File2 = path.join(basePath, 'versions', '1.4', '2-error.js'),
+            migrationsv15File1 = path.join(basePath, 'versions', '1.5', '1-no-error.js'),
+            migratorConfigPath = path.join(__dirname, '..', 'assets', 'MigratorConfig.js'),
             connection;
 
         before(function () {
@@ -94,12 +94,12 @@ _.each(['default', 'migrateInit'], function (initMethod) {
             });
 
             knexMigrator = new KnexMigrator({
-                knexMigratorFilePath: __dirname + '/assets'
+                knexMigratorFilePath: path.join(__dirname, '..', 'assets')
             });
         });
 
         before(function () {
-            return knexMigrator.reset();
+            return knexMigrator.reset({force: true});
         });
 
         before(function () {

--- a/test/functional/implicit_commits_spec.js
+++ b/test/functional/implicit_commits_spec.js
@@ -1,9 +1,9 @@
 const _ = require('lodash'),
     path = require('path'),
     fs = require('fs'),
-    config = require('../config'),
-    KnexMigrator = require('../lib'),
-    testUtils = require('./utils');
+    config = require('../../config'),
+    KnexMigrator = require('../../lib'),
+    testUtils = require('../utils');
 
 let migratorConfigPath,
     migrationPath;
@@ -16,8 +16,8 @@ describe('Implicit Commits', function () {
     describe('knex-migrator init', function () {
         describe('fail #1', function () {
             before(function () {
-                migratorConfigPath = path.join(__dirname, 'assets', 'migrations_1', 'MigratorConfig.js');
-                migrationPath = path.join(__dirname, 'assets', 'migrations_1');
+                migratorConfigPath = path.join(__dirname, '..', 'assets', 'migrations_1', 'MigratorConfig.js');
+                migrationPath = path.join(__dirname, '..', 'assets', 'migrations_1');
 
                 testUtils.writeMigratorConfig({
                     migratorConfigPath: migratorConfigPath,
@@ -62,8 +62,8 @@ describe('Implicit Commits', function () {
 
         describe('fail #2', function () {
             before(function () {
-                migratorConfigPath = path.join(__dirname, 'assets', 'migrations_2', 'MigratorConfig.js');
-                migrationPath = path.join(__dirname, 'assets', 'migrations_2');
+                migratorConfigPath = path.join(__dirname, '..', 'assets', 'migrations_2', 'MigratorConfig.js');
+                migrationPath = path.join(__dirname, '..', 'assets', 'migrations_2');
 
                 testUtils.writeMigratorConfig({
                     migratorConfigPath: migratorConfigPath,
@@ -111,8 +111,8 @@ describe('Implicit Commits', function () {
 
         describe('success #1', function () {
             before(function () {
-                migratorConfigPath = path.join(__dirname, 'assets', 'migrations_3', 'MigratorConfig.js');
-                migrationPath = path.join(__dirname, 'assets', 'migrations_3');
+                migratorConfigPath = path.join(__dirname, '..', 'assets', 'migrations_3', 'MigratorConfig.js');
+                migrationPath = path.join(__dirname, '..', 'assets', 'migrations_3');
 
                 testUtils.writeMigratorConfig({
                     migratorConfigPath: migratorConfigPath,
@@ -155,8 +155,8 @@ describe('Implicit Commits', function () {
     describe('knex-migrator migrate', function () {
         describe('fail #1', function () {
             before(function () {
-                migratorConfigPath = path.join(__dirname, 'assets', 'migrations_4', 'MigratorConfig.js');
-                migrationPath = path.join(__dirname, 'assets', 'migrations_4');
+                migratorConfigPath = path.join(__dirname, '..', 'assets', 'migrations_4', 'MigratorConfig.js');
+                migrationPath = path.join(__dirname, '..', 'assets', 'migrations_4');
 
                 testUtils.writeMigratorConfig({
                     migratorConfigPath: migratorConfigPath,
@@ -232,8 +232,8 @@ describe('Implicit Commits', function () {
 
         describe('success #1', function () {
             before(function () {
-                migratorConfigPath = path.join(__dirname, 'assets', 'migrations_5', 'MigratorConfig.js');
-                migrationPath = path.join(__dirname, 'assets', 'migrations_5');
+                migratorConfigPath = path.join(__dirname, '..', 'assets', 'migrations_5', 'MigratorConfig.js');
+                migrationPath = path.join(__dirname, '..', 'assets', 'migrations_5');
 
                 testUtils.writeMigratorConfig({
                     migratorConfigPath: migratorConfigPath,

--- a/test/functional/rollback_2_spec.js
+++ b/test/functional/rollback_2_spec.js
@@ -1,21 +1,22 @@
 const _ = require('lodash'),
     path = require('path'),
     sinon = require('sinon'),
+    should = require('should'),
     fs = require('fs'),
-    KnexMigrator = require('../lib'),
-    testUtils = require('./utils');
+    KnexMigrator = require('../../lib'),
+    testUtils = require('../utils');
 
 const sandbox = sinon.createSandbox();
 
-describe('knex-migrator rollback (default)', function () {
+describe('knex-migrator rollback (force)', function () {
     this.timeout(1000 * 10);
 
     let knexMigrator,
-        migrationPath = path.join(__dirname, 'assets', 'migrations_6'),
-        migratorConfigPath = __dirname + '/assets/MigratorConfig.js',
-        versionsFolder = __dirname + '/assets/migrations_6/versions',
-        migration121 = __dirname + '/assets/migrations_6/versions/1.21',
-        migration121File = __dirname + '/assets/migrations_6/versions/1.21/1-test.js',
+        migrationPath = path.join(__dirname, '..', 'assets', 'migrations_6'),
+        migratorConfigPath = path.join(__dirname, '..', 'assets', 'MigratorConfig.js'),
+        versionsFolder = path.join(__dirname, '..', 'assets', 'migrations_6', 'versions'),
+        migration121 = path.join(__dirname, '..', 'assets', 'migrations_6', 'versions', '1.21'),
+        migration121File = path.join(__dirname, '..', 'assets', 'migrations_6', 'versions', '1.21', '1-test.js'),
         connection;
 
     before(function () {
@@ -38,7 +39,7 @@ describe('knex-migrator rollback (default)', function () {
         });
 
         knexMigrator = new KnexMigrator({
-            knexMigratorFilePath: __dirname + '/assets'
+            knexMigratorFilePath: path.join(__dirname, '..', 'assets')
         });
     });
 
@@ -99,22 +100,19 @@ describe('knex-migrator rollback (default)', function () {
         });
 
         fs.writeFileSync(migration121File, jsFile);
-        knexMigrator.currentVersion = '1.21';
-        return knexMigrator.migrate();
+
+        // we have to force, because we are still on 1.20
+        return knexMigrator.migrate({force: true});
     });
 
+    // It rolls back all versions on the current version (in the migration table)
     it('knex-migrator rollback', function () {
         return knexMigrator.rollback({force: true});
     });
 
+    // Shows only a warning that 1.21 is available
     it('knex-migrator health', function () {
-        return knexMigrator.isDatabaseOK()
-            .then(function () {
-                'Database should not be okay'.should.eql(false);
-            })
-            .catch(function (err) {
-                err.message.should.eql('Migrations are missing. Please run `knex-migrator migrate`.');
-            });
+        return knexMigrator.isDatabaseOK();
     });
 
     it('db check', function () {
@@ -122,15 +120,5 @@ describe('knex-migrator rollback (default)', function () {
             .then(function (migrations) {
                 migrations.length.should.eql(2);
             });
-    });
-
-    it('knex-migrator rollback', function () {
-        return knexMigrator.rollback({force: true})
-            .then(function () {
-                'No rollback expected.'.should.eql(false);
-            })
-            .catch(function (err) {
-                err.message.should.eql('No migrations available to rollback.');
-            })
     });
 });

--- a/test/functional/rollback_3_spec.js
+++ b/test/functional/rollback_3_spec.js
@@ -2,8 +2,8 @@ const _ = require('lodash'),
     path = require('path'),
     sinon = require('sinon'),
     fs = require('fs'),
-    KnexMigrator = require('../lib'),
-    testUtils = require('./utils');
+    KnexMigrator = require('../../lib'),
+    testUtils = require('../utils');
 
 const sandbox = sinon.createSandbox();
 
@@ -11,8 +11,8 @@ describe('knex-migrator rollback (on init, auto-rollback)', function () {
     this.timeout(1000 * 10);
 
     let knexMigrator,
-        migrationPath = path.join(__dirname, 'assets', 'migrations_7'),
-        migratorConfigPath = __dirname + '/assets/MigratorConfig.js',
+        migrationPath = path.join(__dirname, '..', 'assets', 'migrations_7'),
+        migratorConfigPath = path.join(__dirname, '..', 'assets', 'MigratorConfig.js'),
         connection;
 
     before(function () {
@@ -23,7 +23,7 @@ describe('knex-migrator rollback (on init, auto-rollback)', function () {
         });
 
         knexMigrator = new KnexMigrator({
-            knexMigratorFilePath: __dirname + '/assets'
+            knexMigratorFilePath: path.join(__dirname, '..', 'assets')
         });
     });
 

--- a/test/functional/rollback_4_spec.js
+++ b/test/functional/rollback_4_spec.js
@@ -4,8 +4,8 @@ const _ = require('lodash'),
     should = require('should'),
     rimraf = require('rimraf'),
     fs = require('fs'),
-    KnexMigrator = require('../lib'),
-    testUtils = require('./utils');
+    KnexMigrator = require('../../lib'),
+    testUtils = require('../utils');
 
 const sandbox = sinon.createSandbox();
 
@@ -13,9 +13,9 @@ describe('knex-migrator rollback (to specific version)', function () {
     this.timeout(1000 * 10);
 
     let knexMigrator,
-        migrationPath = path.join(__dirname, 'assets', 'migrations_6'),
-        migratorConfigPath = __dirname + '/assets/MigratorConfig.js',
-        versionsFolder = __dirname + '/assets/migrations_6/versions',
+        migrationPath = path.join(__dirname, '..', 'assets', 'migrations_6'),
+        migratorConfigPath = path.join(__dirname, '..', 'assets', 'MigratorConfig.js'),
+        versionsFolder = path.join(__dirname, '..', 'assets', 'migrations_6', 'versions'),
         migrations = [],
         connection;
 
@@ -31,7 +31,7 @@ describe('knex-migrator rollback (to specific version)', function () {
         });
 
         knexMigrator = new KnexMigrator({
-            knexMigratorFilePath: __dirname + '/assets'
+            knexMigratorFilePath: path.join(__dirname, '..', 'assets')
         });
     });
 

--- a/test/unit/_rollback_spec.js
+++ b/test/unit/_rollback_spec.js
@@ -1,0 +1,181 @@
+const sinon = require('sinon');
+const should = require('should');
+const KnexMigrator = require('../../lib');
+const utils = require('../../lib/utils');
+const sandbox = sinon.createSandbox();
+
+describe('Unit: _rollback', function () {
+    afterEach(function () {
+        sandbox.restore();
+    });
+
+    it('manual rollback', function () {
+        const knexMigrator = new KnexMigrator({
+            knexMigratorConfig: {
+                database: {},
+                migrationPath: 'location',
+                currentVersion: '1.9'
+            }
+        });
+
+        knexMigrator.connection = sandbox.stub().returns({
+            where: sandbox.stub().returns({
+                delete: sandbox.stub()
+            })
+        });
+
+        const tasks = [
+            {
+                up: sandbox.stub(),
+                down: sandbox.stub().resolves(),
+                name: '1-something'
+            },
+            {
+                up: sandbox.stub(),
+                down: sandbox.stub().resolves(),
+                name: '2-something'
+            }
+        ];
+
+        sandbox.stub(utils, 'readTasks').returns(tasks);
+
+        return knexMigrator._rollback({
+            version: '1.10'
+        }).then(function () {
+            tasks[0].down.called.should.eql(true);
+            tasks[1].down.called.should.eql(true);
+        });
+    });
+
+    it('rollback caused by an error during migration', function () {
+        const knexMigrator = new KnexMigrator({
+            knexMigratorConfig: {
+                database: {},
+                migrationPath: 'location',
+                currentVersion: '1.9'
+            }
+        });
+
+        knexMigrator.connection = sandbox.stub().returns({
+            where: sandbox.stub().returns({
+                delete: sandbox.stub()
+            })
+        });
+
+        const tasks = [
+            {
+                up: sandbox.stub(),
+                down: sandbox.stub().resolves(),
+                name: '1-something'
+            },
+            {
+                up: sandbox.stub(),
+                down: sandbox.stub().resolves(),
+                name: '2-something'
+            }
+        ];
+
+        sandbox.stub(utils, 'readTasks').returns(tasks);
+
+        return knexMigrator._rollback({
+            version: '1.10',
+            task: tasks[0]
+        }).then(function () {
+            tasks[0].down.called.should.eql(true);
+            tasks[1].down.called.should.eql(false);
+        });
+    });
+
+    it('rollback caused by an error during migration', function () {
+        const knexMigrator = new KnexMigrator({
+            knexMigratorConfig: {
+                database: {},
+                migrationPath: 'location',
+                currentVersion: '1.9'
+            }
+        });
+
+        knexMigrator.connection = sandbox.stub().returns({
+            where: sandbox.stub().returns({
+                delete: sandbox.stub()
+            })
+        });
+
+        const tasks = [
+            {
+                up: sandbox.stub(),
+                down: sandbox.stub().resolves(),
+                name: '1-something',
+                config: {
+                    transaction: true
+                }
+            },
+            {
+                up: sandbox.stub(),
+                down: sandbox.stub().resolves(),
+                name: '2-something'
+            }
+        ];
+
+        sandbox.stub(utils, 'readTasks').returns(tasks);
+
+        return knexMigrator._rollback({
+            version: '1.10',
+            task: tasks[0]
+        }).then(function () {
+            tasks[0].down.called.should.eql(false);
+            tasks[1].down.called.should.eql(false);
+        });
+    });
+
+    it('rollback caused by an error during migration', function () {
+        const knexMigrator = new KnexMigrator({
+            knexMigratorConfig: {
+                database: {},
+                migrationPath: 'location',
+                currentVersion: '1.9'
+            }
+        });
+
+        knexMigrator.connection = sandbox.stub().returns({
+            where: sandbox.stub().returns({
+                delete: sandbox.stub()
+            })
+        });
+
+        const tasks = [
+            {
+                up: sandbox.stub(),
+                down: sandbox.stub().resolves(),
+                name: '1-something'
+            },
+            {
+                up: sandbox.stub(),
+                down: sandbox.stub().resolves(),
+                name: '2-something'
+            },
+            {
+                up: sandbox.stub(),
+                down: sandbox.stub().resolves(),
+                name: '3-something'
+            },
+            {
+                up: sandbox.stub(),
+                down: sandbox.stub().resolves(),
+                name: '4-something'
+            }
+        ];
+
+        sandbox.stub(utils, 'readTasks').returns(tasks);
+
+        return knexMigrator._rollback({
+            version: '1.10',
+            task: tasks[2]
+        }).then(function () {
+            tasks[0].down.called.should.eql(true);
+            tasks[1].down.called.should.eql(true);
+            tasks[2].down.called.should.eql(true);
+            tasks[3].down.called.should.eql(false);
+        });
+    });
+});


### PR DESCRIPTION
no issue

- do not rollback all tasks of a version
- e.g.
  - version 2.0 has 4 scripts
  - it failed in the second script
  - we don't have to rollback all 4 scripts
  - only the second and the first
    - only rollback the second if it wasn't running in a transaction