### PR TITLE
Added support for "Irreversible migrations"

### DIFF
--- a/lib/errors.js
+++ b/lib/errors.js
@@ -56,6 +56,12 @@ const knexMigratorErrors = {
             id: 500,
             errorType: 'DatabaseError'
         }, options));
+    },
+    IrreversibleMigrationError: function IrreversibleMigrationError(options) {
+        KnexMigrateError.call(this, Object.assign({
+            id: 500,
+            errorType: 'IrreversibleMigrationError'
+        }, options));
     }
 };
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -865,6 +865,18 @@ KnexMigrator.prototype._rollback = function _rollback(options) {
         tasks = newTasks;
     }
 
+    // CASE: one of the migrations that are about to be rolled back is marked as irreversible. Exit early without performing any actions
+    const irreversibleMigrations = _.filter(tasks, function (task) {
+        return !!_.get(task, 'config.irreversible');
+    });
+    if (irreversibleMigrations.length) {
+        return Promise.reject(new errors.IrreversibleMigrationError({
+            message: 'Unable to rollback',
+            help: 'There are irreversible migrations when rolling back to the selected version, this typically means data required for earlier versions has been deleted. Please restore from a backup instead.',
+            code: 'IRREVERSIBLE_MIGRATION'
+        }));
+    }
+
     tasks.reverse();
 
     return Promise.each(tasks, function (task) {

--- a/test/unit/_rollback_spec.js
+++ b/test/unit/_rollback_spec.js
@@ -177,4 +177,103 @@ describe('Unit: _rollback', function () {
             tasks[3].down.called.should.eql(false);
         });
     });
+
+    it('aborts with irreversible migrations in manual rollback', function () {
+        const knexMigrator = new KnexMigrator({
+            knexMigratorConfig: {
+                database: {},
+                migrationPath: 'location',
+                currentVersion: '3.0'
+            }
+        });
+
+        knexMigrator.connection = sinon.stub().returns({
+            where: sinon.stub().returns({
+                delete: sinon.stub()
+            })
+        });
+
+        const tasks = [
+            {
+                up: sinon.stub(),
+                down: sinon.stub().resolves(),
+                name: '1-something'
+            },
+            {
+                config: {irreversible: true},
+                up: sinon.stub(),
+                down: sinon.stub().resolves(),
+                name: '2-something'
+            },
+            {
+                up: sinon.stub(),
+                down: sinon.stub().resolves(),
+                name: '3-something'
+            }
+        ];
+
+        sinon.stub(utils, 'readTasks').returns(tasks);
+
+        return knexMigrator._rollback({
+            version: '2.31'
+        }).then(function () {
+            true.should.eql(false);
+        }).catch((err) => {
+            should.exist(err);
+            err.errorType.should.eql('IrreversibleMigrationError');
+            tasks[0].down.called.should.eql(false);
+            tasks[1].down.called.should.eql(false);
+            tasks[2].down.called.should.eql(false);
+        });
+    });
+
+    it('aborts with irreversible migrations in automatical failure rollback', function () {
+        const knexMigrator = new KnexMigrator({
+            knexMigratorConfig: {
+                database: {},
+                migrationPath: 'location',
+                currentVersion: '3.0'
+            }
+        });
+
+        knexMigrator.connection = sinon.stub().returns({
+            where: sinon.stub().returns({
+                delete: sinon.stub()
+            })
+        });
+
+        const tasks = [
+            {
+                up: sinon.stub(),
+                down: sinon.stub().resolves(),
+                name: '1-something'
+            },
+            {
+                config: {irreversible: true},
+                up: sinon.stub(),
+                down: sinon.stub().resolves(),
+                name: '2-something'
+            },
+            {
+                up: sinon.stub(),
+                down: sinon.stub().resolves(),
+                name: '3-something'
+            }
+        ];
+
+        sinon.stub(utils, 'readTasks').returns(tasks);
+
+        return knexMigrator._rollback({
+            version: '2.31',
+            task: tasks[2]
+        }).then(function () {
+            true.should.eql(false);
+        }).catch((err) => {
+            should.exist(err);
+            err.errorType.should.eql('IrreversibleMigrationError');
+            tasks[0].down.called.should.eql(false);
+            tasks[1].down.called.should.eql(false);
+            tasks[2].down.called.should.eql(false);
+        });
+    });
 });


### PR DESCRIPTION
no issue

- some migrations that drop tables which include data will mean that even though the `down` task could re-create the database schema it's still of no use when the data is missing
- adds support for specifying this in tasks' config with `module.exports.config = {irreversible: true}`
- if an irreversible migration is included in a rollback task list then an error will be thrown immediately with no tasks being run

TODO:
- [ ] wording review