### PR TITLE
Ignored dotfiles in versions folder

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -122,6 +122,12 @@ exports.readVersionFolders = function readFolders(absolutePath) {
     folders.forEach((folderToAdd) => {
         let index = null;
 
+        // CASE: ignore dot files
+        if (folderToAdd.match(/^\./)) {
+            debug('Ignore Dotfile: ' + folderToAdd);
+            return;
+        }
+
         toReturn.forEach((existingElement, _index) => {
             if (index !== null) {
                 return;


### PR DESCRIPTION
- closes #174

Tested by adding a dotfile to `test` directory, run tests (mostly fail), make change, re-run test & they pass.