### PR TITLE
Added collation to create table statement

### DIFF
--- a/lib/database.js
+++ b/lib/database.js
@@ -21,6 +21,7 @@ exports.connect = function connect(options) {
     if (client === 'mysql') {
         options.connection.timezone = options.connection.timezone || 'UTC';
         options.connection.charset = options.connection.charset || 'utf8mb4';
+        options.connection.collation = options.connection.collation || 'utf8mb4_general_ci';
     }
 
     return knex(options);
@@ -95,7 +96,8 @@ exports.createMigrationsTable = function createMigrationsTable(connection) {
  */
 exports.createDatabaseIfNotExist = function createDatabaseIfNotExist(dbConfig) {
     const name = dbConfig.connection.database,
-        charset = dbConfig.connection.charset || 'utf8mb4';
+        charset = dbConfig.connection.charset || 'utf8mb4',
+        collation = dbConfig.connection.collation || 'utf8mb4_general_ci';
 
     // @NOTE: Skip, because sqlite3 is a file based database.
     if (dbConfig.client === 'sqlite3') {
@@ -115,7 +117,7 @@ exports.createDatabaseIfNotExist = function createDatabaseIfNotExist(dbConfig) {
 
     return exports.ensureConnectionWorks(connection)
         .then(function () {
-            return connection.raw('CREATE DATABASE `' + name + '` CHARACTER SET ' + charset + ';');
+            return connection.raw('CREATE DATABASE `' + name + '` CHARACTER SET ' + charset + ' COLLATE ' + collation + ';');
         })
         .catch(function (err) {
             // CASE: DB exists


### PR DESCRIPTION
On MySQL 8, the default collation changed from `utf8mb4_general_ci` to `utf8mb4_0900_ai_ci`, and Node's MySQL driver doesn't support the new collation (see [here](https://github.com/TryGhost/Ghost/issues/11625#issuecomment-644879046) for more context). As such, this is updating the create database query to explicitly specify the collation, in order to support running Ghost w/MySQL 8.