### PR TITLE
Removed queries against mysql information_schema

### DIFF
--- a/migrations/add-primary-key-to-lock-table.js
+++ b/migrations/add-primary-key-to-lock-table.js
@@ -3,44 +3,48 @@ const debug = require('debug')('knex-migrator:lock-table');
 /**
  * Checks if primary key index exists in a table over the given columns.
  */
-function hasPrimaryKey(tableName, knex) {
+function hasPrimaryKeySQLite(tableName, knex) {
     const client = knex.client.config.client;
 
-    if (client === 'mysql') {
-        const dbName = knex.client.config.connection.database;
-        return knex.raw(`
-                SELECT CONSTRAINT_NAME
-                FROM information_schema.TABLE_CONSTRAINTS
-                WHERE CONSTRAINT_SCHEMA=:dbName
-                AND TABLE_NAME=:tableName
-                AND CONSTRAINT_TYPE='PRIMARY KEY'`, {dbName, tableName})
-            .then(([rawConstraints]) => {
-                return rawConstraints.length > 0;
-            });
-    } else {
-        return knex.raw(`PRAGMA index_list('${tableName}');`)
-            .then((rawConstraints) => {
-                const tablePrimaryKey = rawConstraints.find(c => c.origin === 'pk');
-                return tablePrimaryKey;
-            });
+    if (client !== 'sqlite3') {
+        throw new Error('Must use hasPrimaryKeySQLite on an SQLite3 database');
     }
+
+    return knex.raw(`PRAGMA index_list('${tableName}');`)
+        .then((rawConstraints) => {
+            const tablePrimaryKey = rawConstraints.find(c => c.origin === 'pk');
+            return tablePrimaryKey;
+        });
 }
 
 /**
  * Adds an primary key index to a table over the given columns.
  */
 function addPrimaryKey(tableName, columns, knex) {
-    return hasPrimaryKey(tableName, knex)
-        .then((hasUniqueConstraint) => {
-            if (!hasUniqueConstraint) {
-                debug(`Adding primary key constraint for: ${columns} in table ${tableName}`);
+    const isSQLite = knex.client.config.client === 'sqlite3';
+    if (isSQLite) {
+        return hasPrimaryKeySQLite(tableName, knex)
+            .then((primaryKeyExists) => {
+                if (primaryKeyExists) {
+                    debug(`Primary key constraint for: ${columns} already exists for table: ${tableName}`);
+                    return;
+                }
+
                 return knex.schema.table(tableName, function (table) {
                     table.primary(columns);
                 });
-            } else {
-                debug(`Primary key constraint for: ${columns} already exists for table: ${tableName}`);
-            }
-        });
+            });
+    }
+
+    return knex.schema.table(tableName, function (table) {
+        table.primary(columns);
+    }).catch((err) => {
+        if (err.code === 'ER_MULTIPLE_PRI_KEY') {
+            debug(`Primary key constraint for: ${columns} already exists for table: ${tableName}`);
+            return;
+        }
+        throw err;
+    });
 }
 
 /**


### PR DESCRIPTION
pr https://github.com/TryGhost/Ghost/pull/12739

These queries could be slow when there are a lot of tables/databases, so it's better to avoid them. MySQL provides a good error when failing to add a primary key too.