### PR TITLE
Optimized code for listing migrations

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -119,7 +119,7 @@ KnexMigrator.prototype.init = function init(options) {
                             }
                         })
                         .then(function () {
-                            const initTasks = utils.readTasks(path.join(self.migrationPath, 'init'));
+                            const initTasks = utils.listFiles(path.join(self.migrationPath, 'init'));
 
                             /**
                              * CASE 1: You can disable init completion manually
@@ -159,12 +159,12 @@ KnexMigrator.prototype.init = function init(options) {
                                 // CASE: Run over all migration scripts and add the file name to the database.
                                 return Promise.each(versionsToMigrateTo, function (versionToMigrateTo) {
                                     let versionPath = path.join(self.migrationPath, self.subfolder, versionToMigrateTo);
-                                    let filesToMigrateTo = utils.readTasks(versionPath) || [];
+                                    let filesToMigrateTo = utils.listFiles(versionPath) || [];
 
                                     return Promise.each(filesToMigrateTo, function (fileToMigrateTo) {
                                         // CASE: check if migration exists, do not insert twice
                                         return transacting('migrations')
-                                            .where('name', fileToMigrateTo.name)
+                                            .where('name', fileToMigrateTo)
                                             .then(function (migrationExists) {
                                                 if (migrationExists.length) {
                                                     return Promise.resolve();
@@ -172,7 +172,7 @@ KnexMigrator.prototype.init = function init(options) {
 
                                                 return transacting('migrations')
                                                     .insert({
-                                                        name: fileToMigrateTo.name,
+                                                        name: fileToMigrateTo,
                                                         version: versionToMigrateTo,
                                                         currentVersion: self.currentVersion
                                                     });
@@ -1045,8 +1045,8 @@ KnexMigrator.prototype._migrateTo = function _migrateTo(options) {
                 throw new errors.MigrationScriptError({
                     message: 'Field length of %field% in %table% is too long!'.replace('%field%', field).replace('%table%', table),
                     context: 'This usually happens if your database encoding is utf8mb4.\n' +
-                    'All unique fields and indexes must be lower than 191 characters.\n' +
-                    'Please correct your field length and reset your database with knex-migrator reset.\n',
+                        'All unique fields and indexes must be lower than 191 characters.\n' +
+                        'Please correct your field length and reset your database with knex-migrator reset.\n',
                     help: 'Read more here: https://github.com/TryGhost/knex-migrator/issues/51\n',
                     err: err
                 });
@@ -1208,9 +1208,9 @@ KnexMigrator.prototype._integrityCheck = function _integrityCheck(options) {
                     expected = actual;
 
                 if (version !== 'init') {
-                    expected = utils.readTasks(path.join(self.migrationPath, subfolder, version)).length;
+                    expected = utils.listFiles(path.join(self.migrationPath, subfolder, version)).length;
                 } else {
-                    expected = utils.readTasks(path.join(self.migrationPath, version)).length;
+                    expected = utils.listFiles(path.join(self.migrationPath, version)).length;
                 }
 
                 debug('Version ' + version + ' expected: ' + expected);

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -46,15 +46,13 @@ module.exports.loadConfig = function loadConfig(options) {
 };
 
 /**
- * @description Reads all migration files from disk based on a path.
- * It returns an Array of migration files including it's up/down hooks, config and the name.
+ * @description List all migration files from disk based on a path.
  *
  * @param absolutePath
  * @returns {Array}
  */
-exports.readTasks = function readTasks(absolutePath) {
-    let files = [],
-        tasks = [];
+exports.listFiles = function listFiles(absolutePath) {
+    let files = [];
 
     try {
         files = fs.readdirSync(absolutePath);
@@ -65,13 +63,28 @@ exports.readTasks = function readTasks(absolutePath) {
         });
     }
 
-    _.each(files, function (file) {
+    files = files.filter(function (file) {
         // CASE: ignore dot files
-        if (file.match(/^\./)) {
-            debug('Ignore Dotfile: ' + file);
-            return;
-        }
+        return !file.match(/^\./);
+    });
 
+    debug(files);
+    return files;
+};
+
+/**
+ * @description Reads all migration files from disk based on a path.
+ * It returns an Array of migration files including it's up/down hooks, config and the name.
+ *
+ * @param absolutePath
+ * @returns {Array}
+ */
+exports.readTasks = function readTasks(absolutePath) {
+    let tasks = [];
+
+    const files = exports.listFiles(absolutePath);
+
+    _.each(files, function (file) {
         let executeFn = require(path.join(absolutePath, file));
 
         try {
@@ -92,7 +105,7 @@ exports.readTasks = function readTasks(absolutePath) {
         }
     });
 
-    debug(files);
+    debug(tasks);
     return tasks;
 };
 


### PR DESCRIPTION
no issue

- throughout the code, there are several places where we call our
  `readTasks` function to return a list of migrations in a folder
- this function gets all the files in a dir and requires them so it can
  populate an object with the up/down functions and the config
- we don't need this information in some places because we're often just
  using the names of the migrations, or counting how many migrations there are
- this commit extracts the code to get a list of files into a
  `listFiles` function, which simply lists the files (and excludes dot
  directories) - this is then used within `readTasks`
- this also switches the places in our code, that was calling `readTasks` but
  didn't need the migration functions or config, to `listFiles`
- in Ghost this saves about 5% of the on-stack time during boot up and
  avoids requiring a bunch of files