### PR TITLE
Updated CI Node versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
     if: github.event_name == 'push' || (github.event_name == 'pull_request' && !startsWith(github.head_ref, 'renovate/'))
     strategy:
       matrix:
-        node: [ '12.10.0', '14.14.0' ]
+        node: [ '12.22.1', '14.16.1' ]
         env:
           - DB: sqlite3
             NODE_ENV: testing


### PR DESCRIPTION
refs https://github.com/TryGhost/Ghost/blob/main/package.json#L49

- this commit bumps the Node versions used in CI to the minimum
  supported by Ghost