### PR TITLE
Fixed rollbacks after an error during migration

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -2,5 +2,8 @@ module.exports = {
     plugins: ['ghost'],
     extends: [
         'plugin:ghost/node'
-    ]
+    ],
+    parserOptions: {
+        ecmaVersion: 2018
+    }
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -356,13 +356,14 @@ KnexMigrator.prototype.migrate = async function migrate(options) {
         });
 
         if (versionsToMigrate.length) {
-            logging.info('Running migrations.');
             if (hooks.before) {
                 debug('Before hook');
                 await hooks.before({
                     connection: this.connection
                 });
             }
+
+            logging.info('Running migrations.');
 
             for (const versionToMigrate of versionsToMigrate) {
                 try {

--- a/lib/index.js
+++ b/lib/index.js
@@ -414,6 +414,8 @@ KnexMigrator.prototype.migrate = async function migrate(options) {
                             err: innerErr,
                             context: `OuterError: ${err.message}`
                         });
+                    } finally {
+                        await locking.unlock(this.connection);
                     }
                 }
             }
@@ -425,9 +427,8 @@ KnexMigrator.prototype.migrate = async function migrate(options) {
                 });
             }
         }
-    } finally {
         await locking.unlock(this.connection);
-
+    } finally {
         if (hooks.shutdown) {
             debug('Shutdown hook');
             await hooks.shutdown({

--- a/lib/index.js
+++ b/lib/index.js
@@ -380,7 +380,6 @@ KnexMigrator.prototype.migrate = async function migrate(options) {
             }
         }
 
-        await locking.unlock(this.connection);
     } catch (err) {
         // CASE: Do not rollback if migrations are locked
         if (err instanceof errors.MigrationsAreLockedError) {
@@ -420,10 +419,10 @@ KnexMigrator.prototype.migrate = async function migrate(options) {
                 err: innerErr,
                 context: `OuterError: ${err.message}`
             });
-        } finally {
-            await locking.unlock(self.connection);
         }
     } finally {
+        await locking.unlock(this.connection);
+
         if (hooks.shutdown) {
             debug('Shutdown hook');
             await hooks.shutdown({

--- a/lib/index.js
+++ b/lib/index.js
@@ -286,11 +286,10 @@ KnexMigrator.prototype.init = function init(options) {
  * @param {Object} options - Custom options you can pass in (version, force, init, only, skip)
  * @returns {Bluebird<any>}
  */
-KnexMigrator.prototype.migrate = function migrate(options) {
+KnexMigrator.prototype.migrate = async function migrate(options) {
     options = options || {};
 
-    let self = this,
-        onlyVersion = options.version,
+    let onlyVersion = options.version,
         force = options.force,
         init = options.init,
         onlyFile = options.only,
@@ -308,14 +307,12 @@ KnexMigrator.prototype.migrate = function migrate(options) {
 
     // CASE: `--init` flag is passed. Combo feature.
     if (init) {
-        return this.init()
-            .then(function () {
-                return self.migrate(_.omit(options, 'init'));
-            });
+        await this.init()
+        return this.migrate(_.omit(options, 'init'));
     }
 
     try {
-        hooks = require(path.join(self.migrationPath, '/hooks/migrate'));
+        hooks = require(path.join(this.migrationPath, '/hooks/migrate'));
     } catch (err) {
         debug('Hook Error: ' + err.message);
         debug('No hooks found, no problem.');
@@ -323,152 +320,121 @@ KnexMigrator.prototype.migrate = function migrate(options) {
 
     this.connection = database.connect(this.dbConfig);
 
-    return database.ensureConnectionWorks(this.connection)
-        .then(function () {
-            return migrations.run(self.connection);
-        })
-        .then(function () {
-            return locking.lock(self.connection);
-        })
-        .then(function () {
-            return self._integrityCheck({
-                force: force
-            });
-        })
-        .then(function (result) {
-            _.each(result, function (value, version) {
-                // CASE: Log which versions won't be executed based on the "only" flag
-                if (onlyVersion && version !== onlyVersion) {
-                    debug('Do not execute: ' + version);
-                    return;
-                }
-            });
+    try {
+        await database.ensureConnectionWorks(this.connection);
 
-            if (onlyVersion) {
-                // CASE: filter out versions which should not run
-                let containsVersion = _.find(result, function (obj, key) {
-                    return key === onlyVersion;
-                });
+        await migrations.run(this.connection);
 
-                if (!containsVersion) {
-                    logging.warn('Cannot find requested version: ' + onlyVersion);
-                }
-            }
+        await locking.lock(this.connection);
 
-            _.each(result, function (value, version) {
-                // CASE: compare files on disk with files in database
-                if (value.expected !== value.actual) {
-                    debug('Need to execute migrations for: ' + version);
-                    versionsToMigrate.push(version);
-                }
-            });
-        })
-        .then(function executeBeforeHook() {
-            if (!versionsToMigrate.length) {
+        const result = await this._integrityCheck({force});
+
+        _.each(result, function (_value, version) {
+            // CASE: Log which versions won't be executed based on the "only" flag
+            if (onlyVersion && version !== onlyVersion) {
+                debug('Do not execute: ' + version);
                 return;
             }
+        });
 
+        if (onlyVersion) {
+            // CASE: filter out versions which should not run
+            let containsVersion = _.find(result, function (_obj, key) {
+                return key === onlyVersion;
+            });
+
+            if (!containsVersion) {
+                logging.warn('Cannot find requested version: ' + onlyVersion);
+            }
+        }
+
+        _.each(result, function (value, version) {
+            // CASE: compare files on disk with files in database
+            if (value.expected !== value.actual) {
+                debug('Need to execute migrations for: ' + version);
+                versionsToMigrate.push(version);
+            }
+        });
+
+        if (versionsToMigrate.length) {
             if (hooks.before) {
                 debug('Before hook');
-                return hooks.before({
-                    connection: self.connection
+                await hooks.before({
+                    connection: this.connection
                 });
             }
-        })
-        .then(function executeMigrations() {
-            if (!versionsToMigrate.length) {
-                return;
-            }
 
-            return Promise.each(versionsToMigrate, function (versionToMigrate) {
-                return self._migrateTo({
+            for (const versionToMigrate of versionsToMigrate) {
+                await this._migrateTo({
                     version: versionToMigrate,
                     only: onlyFile,
                     hooks: hooks
                 });
-            });
-        })
-        .then(function executeAfterHook() {
-            if (!versionsToMigrate.length) {
-                return;
             }
 
             if (hooks.after) {
                 debug('After hook');
-                return hooks.after({
-                    connection: self.connection
+                await hooks.after({
+                    connection: this.connection
                 });
             }
-        })
-        .then(function () {
-            return locking.unlock(self.connection);
-        })
-        .catch(function (err) {
-            // CASE: Do not rollback if migrations are locked
-            if (err instanceof errors.MigrationsAreLockedError) {
+        }
+
+        await locking.unlock(this.connection);
+    } catch (err) {
+        // CASE: Do not rollback if migrations are locked
+        if (err instanceof errors.MigrationsAreLockedError) {
+            throw err;
+        }
+
+        // CASE: Do not rollback migration scripts, if lock error
+        if (err instanceof errors.LockError) {
+            throw err;
+        }
+
+        // CASE: ETIMEDOUT, ENOTFOUND
+        if (err instanceof errors.DatabaseError) {
+            throw err;
+        }
+
+        if (err.context && err.context.name) {
+            debug(`Task failed: ${err.context.name}`);
+        }
+
+        debug(`Rolling back: ${err.message}`);
+
+        versionsToMigrate.reverse();
+
+        try {
+            for (const version of versionsToMigrate) {
+                await this._rollback({version: version, task: err.context});
+            }
+            throw err;
+        } catch (innerErr) {
+            if (errors.utils.isIgnitionError(innerErr)) {
                 throw err;
             }
 
-            // CASE: Do not rollback migration scripts, if lock error
-            if (err instanceof errors.LockError) {
-                throw err;
-            }
-
-            // CASE: ETIMEDOUT, ENOTFOUND
-            if (err instanceof errors.DatabaseError) {
-                throw err;
-            }
-
-            if (err.context && err.context.name) {
-                debug(`Task failed: ${err.context.name}`);
-            }
-
-            debug(`Rolling back: ${err.message}`);
-
-            versionsToMigrate.reverse();
-
-            // CASE: rollback in reversed order
-            return Promise.each(versionsToMigrate, function (version) {
-                return self._rollback({version: version, task: err.context});
-            }).then(function () {
-                throw err;
-            }).catch(function (innerErr) {
-                if (errors.utils.isIgnitionError(innerErr)) {
-                    throw err;
-                }
-
-                throw new errors.RollbackError({
-                    message: innerErr.message,
-                    err: innerErr,
-                    context: `OuterError: ${err.message}`
-                });
-            }).finally(function () {
-                return locking.unlock(self.connection);
+            throw new errors.RollbackError({
+                message: innerErr.message,
+                err: innerErr,
+                context: `OuterError: ${err.message}`
             });
-        }).finally(function () {
-            let ops = [];
-
-            if (hooks.shutdown) {
-                ops.push(function shutdownHook() {
-                    debug('Shutdown hook');
-                    return hooks.shutdown({
-                        executedFromShell: self.executedFromShell
-                    });
-                });
-            }
-
-            ops.push(function destroyConnection() {
-                debug('Destroy connection');
-                return self.connection.destroy()
-                    .then(function () {
-                        debug('Destroyed connection');
-                    });
+        } finally {
+            await locking.unlock(self.connection);
+        }
+    } finally {
+        if (hooks.shutdown) {
+            debug('Shutdown hook');
+            await hooks.shutdown({
+                executedFromShell: this.executedFromShell
             });
+        }
 
-            return Promise.each(ops, function (op) {
-                return op.bind(self)();
-            });
-        });
+        debug('Destroy connection');
+        await this.connection.destroy();
+        debug('Destroyed connection');
+    }
 };
 
 /**

--- a/lib/index.js
+++ b/lib/index.js
@@ -872,7 +872,7 @@ KnexMigrator.prototype._rollback = function _rollback(options) {
                 .delete();
         }
 
-        debug('Rollback', task.name);
+        logging.warn('Rollback', task.name);
 
         if (task.config && task.config.transaction) {
             return database.createTransaction(self.connection, function (txn) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -371,6 +371,21 @@ KnexMigrator.prototype.migrate = async function migrate(options) {
                         hooks: hooks
                     });
                 } catch (err) {
+                    // CASE: Do not rollback if migrations are locked
+                    if (err instanceof errors.MigrationsAreLockedError) {
+                        throw err;
+                    }
+
+                    // CASE: Do not rollback migration scripts, if lock error
+                    if (err instanceof errors.LockError) {
+                        throw err;
+                    }
+
+                    // CASE: ETIMEDOUT, ENOTFOUND
+                    if (err instanceof errors.DatabaseError) {
+                        throw err;
+                    }
+
                     if (err.context && err.context.name) {
                         debug(`Task failed: ${err.context.name}`);
                     }

--- a/lib/index.js
+++ b/lib/index.js
@@ -364,11 +364,43 @@ KnexMigrator.prototype.migrate = async function migrate(options) {
             }
 
             for (const versionToMigrate of versionsToMigrate) {
-                await this._migrateTo({
-                    version: versionToMigrate,
-                    only: onlyFile,
-                    hooks: hooks
-                });
+                try {
+                    await this._migrateTo({
+                        version: versionToMigrate,
+                        only: onlyFile,
+                        hooks: hooks
+                    });
+                } catch (err) {
+                    if (err.context && err.context.name) {
+                        debug(`Task failed: ${err.context.name}`);
+                    }
+
+                    debug(`Rolling back: ${err.message}`);
+
+                    const versionsMigrated = versionsToMigrate.slice(
+                        0,
+                        versionsToMigrate.indexOf(versionToMigrate) + 1
+                    );
+
+                    versionsMigrated.reverse();
+
+                    try {
+                        for (const versionMigrated of versionsMigrated) {
+                            await this._rollback({version: versionMigrated, task: err.context});
+                        }
+                        throw err;
+                    } catch (innerErr) {
+                        if (errors.utils.isIgnitionError(innerErr)) {
+                            throw err;
+                        }
+
+                        throw new errors.RollbackError({
+                            message: innerErr.message,
+                            err: innerErr,
+                            context: `OuterError: ${err.message}`
+                        });
+                    }
+                }
             }
 
             if (hooks.after) {
@@ -377,47 +409,6 @@ KnexMigrator.prototype.migrate = async function migrate(options) {
                     connection: this.connection
                 });
             }
-        }
-
-    } catch (err) {
-        // CASE: Do not rollback if migrations are locked
-        if (err instanceof errors.MigrationsAreLockedError) {
-            throw err;
-        }
-
-        // CASE: Do not rollback migration scripts, if lock error
-        if (err instanceof errors.LockError) {
-            throw err;
-        }
-
-        // CASE: ETIMEDOUT, ENOTFOUND
-        if (err instanceof errors.DatabaseError) {
-            throw err;
-        }
-
-        if (err.context && err.context.name) {
-            debug(`Task failed: ${err.context.name}`);
-        }
-
-        debug(`Rolling back: ${err.message}`);
-
-        versionsToMigrate.reverse();
-
-        try {
-            for (const version of versionsToMigrate) {
-                await this._rollback({version: version, task: err.context});
-            }
-            throw err;
-        } catch (innerErr) {
-            if (errors.utils.isIgnitionError(innerErr)) {
-                throw err;
-            }
-
-            throw new errors.RollbackError({
-                message: innerErr.message,
-                err: innerErr,
-                context: `OuterError: ${err.message}`
-            });
         }
     } finally {
         await locking.unlock(this.connection);

--- a/lib/index.js
+++ b/lib/index.js
@@ -307,8 +307,7 @@ KnexMigrator.prototype.migrate = async function migrate(options) {
 
     // CASE: `--init` flag is passed. Combo feature.
     if (init) {
-        await this.init()
-        return this.migrate(_.omit(options, 'init'));
+        await this.init();
     }
 
     try {

--- a/lib/index.js
+++ b/lib/index.js
@@ -356,6 +356,7 @@ KnexMigrator.prototype.migrate = async function migrate(options) {
         });
 
         if (versionsToMigrate.length) {
+            logging.info('Running migrations.');
             if (hooks.before) {
                 debug('Before hook');
                 await hooks.before({
@@ -390,7 +391,7 @@ KnexMigrator.prototype.migrate = async function migrate(options) {
                         debug(`Task failed: ${err.context.name}`);
                     }
 
-                    debug(`Rolling back: ${err.message}`);
+                    logging.info(`Rolling back: ${err.message}.`);
 
                     const versionsMigrated = versionsToMigrate.slice(
                         0,
@@ -403,6 +404,7 @@ KnexMigrator.prototype.migrate = async function migrate(options) {
                         for (const versionMigrated of versionsMigrated) {
                             await this._rollback({version: versionMigrated, task: err.context});
                         }
+                        logging.info(`Rollback was successful.`);
                         throw err;
                     } catch (innerErr) {
                         if (errors.utils.isIgnitionError(innerErr)) {
@@ -872,7 +874,7 @@ KnexMigrator.prototype._rollback = function _rollback(options) {
                 .delete();
         }
 
-        logging.warn('Rollback', task.name);
+        debug('Rollback', task.name);
 
         if (task.config && task.config.transaction) {
             return database.createTransaction(self.connection, function (txn) {


### PR DESCRIPTION
refs https://github.com/TryGhost/knex-migrator/issues/241

By catching migration errors at the individual level, we're able to only rollback the versions
which have already been migrated. Updating the `migrate` method to use async/await
meant that it was easier to follow the flow control and refactor the error handling to allow
us to correctly rollback.

The eslint file has had it's parser options updated manually because the latest ghost-eslint-plugin
causes a large number of errors, which fixing would be outside the scope of this issue