### PR TITLE
Removed `sqlite3`-specific string checks

### DIFF
--- a/migrations/add-primary-key-to-lock-table.js
+++ b/migrations/add-primary-key-to-lock-table.js
@@ -1,12 +1,11 @@
 const debug = require('debug')('knex-migrator:lock-table');
+const DatabaseInfo = require('@tryghost/database-info');
 
 /**
  * Checks if primary key index exists in a table over the given columns.
  */
 function hasPrimaryKeySQLite(tableName, knex) {
-    const client = knex.client.config.client;
-
-    if (client !== 'sqlite3') {
+    if (!DatabaseInfo.isSQLite(knex)) {
         throw new Error('Must use hasPrimaryKeySQLite on an SQLite3 database');
     }
 
@@ -21,8 +20,7 @@ function hasPrimaryKeySQLite(tableName, knex) {
  * Adds an primary key index to a table over the given columns.
  */
 function addPrimaryKey(tableName, columns, knex) {
-    const isSQLite = knex.client.config.client === 'sqlite3';
-    if (isSQLite) {
+    if (DatabaseInfo.isSQLite(knex)) {
         return hasPrimaryKeySQLite(tableName, knex)
             .then((primaryKeyExists) => {
                 if (primaryKeyExists) {

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "node": "^12.22.1 || ^14.17.0 || ^16.13.0"
   },
   "dependencies": {
+    "@tryghost/database-info": "0.2.5",
     "@tryghost/logging": "2.1.1",
     "bluebird": "3.7.2",
     "commander": "5.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -288,6 +288,11 @@
   dependencies:
     long-timeout "^0.1.1"
 
+"@tryghost/database-info@0.2.5":
+  version "0.2.5"
+  resolved "https://registry.yarnpkg.com/@tryghost/database-info/-/database-info-0.2.5.tgz#d0000d162994b921d900732ab770a23daade56d4"
+  integrity sha512-VbUqHPOfN+7OR1+FVzJzFOEW8TD+nfjNM7Pw7nt1Pt12MEmvHgucf1H7RiOvibwrtvlo6ASJuYOapOb1pSRR2A==
+
 "@tryghost/debug@^0.1.14":
   version "0.1.14"
   resolved "https://registry.yarnpkg.com/@tryghost/debug/-/debug-0.1.14.tgz#e7b748803acca9cf4f664824fb3ee542c5e65041"


### PR DESCRIPTION
refs https://github.com/TryGhost/Toolbox/issues/213

- this commit switches to using `@tryghost/database-info` so we can
  remove some of the specific `"sqlite3"` string checks ahead of moving
  to `better-sqlite3`