### PR TITLE
Switched internal database checks to helper utility

### DIFF
--- a/lib/database.js
+++ b/lib/database.js
@@ -3,6 +3,7 @@ const knex = require('knex'),
     omit = require('lodash/omit'),
     debug = require('debug')('knex-migrator:database'),
     errors = require('./errors');
+const DatabaseInfo = require('@tryghost/database-info');
 
 /**
  * @NOTE: Knex-migrator only supports knex query builder.
@@ -108,9 +109,9 @@ exports.createDatabaseIfNotExist = function createDatabaseIfNotExist(dbConfig) {
         collation = dbConfig.connection.collation || 'utf8mb4_general_ci';
 
     // @NOTE: Skip, because sqlite3 is a file based database.
-    if (dbConfig.client === 'sqlite3') {
+    if (DatabaseInfo.isSQLiteConfig(dbConfig)) {
         return Promise.resolve();
-    } else if (!['mysql', 'mysql2'].includes(dbConfig.client)) {
+    } else if (!DatabaseInfo.isMySQLConfig(dbConfig)) {
         return Promise.reject(new errors.KnexMigrateError({
             message: 'Database is not supported.'
         }));

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "node": "^12.22.1 || ^14.17.0 || ^16.13.0"
   },
   "dependencies": {
-    "@tryghost/database-info": "0.2.5",
+    "@tryghost/database-info": "0.3.0",
     "@tryghost/logging": "2.1.1",
     "bluebird": "3.7.2",
     "commander": "5.1.0",

--- a/test/functional/functional_spec.js
+++ b/test/functional/functional_spec.js
@@ -8,6 +8,8 @@ const _ = require('lodash'),
     errors = require('../../lib/errors'),
     testUtils = require('../utils');
 
+const DatabaseInfo = require('@tryghost/database-info');
+
 const _private = {};
 
 _private.init = function init(knexMigrator, initMethod) {
@@ -182,7 +184,7 @@ _.each(['default', 'migrateInit'], function (initMethod) {
 
                     (err instanceof errors.DatabaseIsNotOkError).should.eql(true);
 
-                    if (config.get('database:client') === 'sqlite3') {
+                    if (DatabaseInfo.isSQLiteConfig(config.get('database'))) {
                         err.code.should.eql('MIGRATION_TABLE_IS_MISSING');
                     } else {
                         err.code.should.eql('DB_NOT_INITIALISED');
@@ -801,7 +803,7 @@ _.each(['default', 'migrateInit'], function (initMethod) {
 
         it('change current version', function () {
             knexMigrator.currentVersion = '1.4';
-            if (config.get('database:client') === 'sqlite3') {
+            if (DatabaseInfo.isSQLiteConfig(config.get('database'))) {
                 return connection.raw(`PRAGMA index_list('migrations_lock');`).then((indexes) => {
                     indexes.filter(index => index.origin === 'pk').length.should.eql(1);
                 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -288,10 +288,10 @@
   dependencies:
     long-timeout "^0.1.1"
 
-"@tryghost/database-info@0.2.5":
-  version "0.2.5"
-  resolved "https://registry.yarnpkg.com/@tryghost/database-info/-/database-info-0.2.5.tgz#d0000d162994b921d900732ab770a23daade56d4"
-  integrity sha512-VbUqHPOfN+7OR1+FVzJzFOEW8TD+nfjNM7Pw7nt1Pt12MEmvHgucf1H7RiOvibwrtvlo6ASJuYOapOb1pSRR2A==
+"@tryghost/database-info@0.3.0":
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/@tryghost/database-info/-/database-info-0.3.0.tgz#8d277965c362379a149daf076ba7018847daca13"
+  integrity sha512-fKCcLAF/BCvU7ux5c0rLqhocaaBziWpbnjSthKC5yZYe94RCrqxsrldcNt17I1N5ytaIOpeXF8TjHD93pePbRQ==
 
 "@tryghost/debug@^0.1.14":
   version "0.1.14"


### PR DESCRIPTION
refs https://github.com/TryGhost/Toolbox/issues/213

- these checks can be abstracted out to the database-info utility and
  save us checking the strings in different places