### PR TITLE
Refactored migrations table creation to use helper

### DIFF
--- a/lib/database.js
+++ b/lib/database.js
@@ -78,23 +78,21 @@ module.exports.createTransaction = function (connection, callback) {
  * @TODO: https://github.com/TryGhost/knex-migrator/issues/91
  * @returns {Bluebird<R> | Bluebird<any> | * | Promise<T>}
  */
-exports.createMigrationsTable = function createMigrationsTable(connection) {
-    return connection('migrations')
-        .catch(function (err) {
-            // CASE: table does not exist
-            if (err.errno === 1 || err.errno === 1146) {
-                debug('Creating table: migrations');
+exports.createMigrationsTable = async function createMigrationsTable(connection) {
+    const hasTable = await connection.schema.hasTable('migrations');
+    if (hasTable) {
+        return;
+    }
 
-                return connection.schema.createTable('migrations', function (table) {
-                    table.increments().primary();
-                    table.string('name');
-                    table.string('version');
-                    table.string('currentVersion');
-                });
-            }
+    // CASE: table does not exist
+    debug('Creating table: migrations');
 
-            throw err;
-        });
+    await connection.schema.createTable('migrations', function (table) {
+        table.increments().primary();
+        table.string('name');
+        table.string('version');
+        table.string('currentVersion');
+    });
 };
 
 /**


### PR DESCRIPTION
- I'm not sure why we're checking IDs here, I presume it's just from
  before knex had built-in utilities
- this commit switches to checking the table via the built-in utility
  instead of checking IDs