### PR TITLE
Added special case for existing DB throwing as unknown error

### DIFF
--- a/lib/database.js
+++ b/lib/database.js
@@ -134,7 +134,7 @@ exports.createDatabaseIfNotExist = function createDatabaseIfNotExist(dbConfig) {
             // CASE: DB exists, but returns an unknown error
             // e.g., providers like PlanetScale
             const isDbExistsMisc =
-                err.errno == 1105 && 
+                err.errno === 1105 && 
                 err.sqlMessage.endsWith("database exists");
         
             if (isDbExistsMisc) {

--- a/lib/database.js
+++ b/lib/database.js
@@ -131,6 +131,16 @@ exports.createDatabaseIfNotExist = function createDatabaseIfNotExist(dbConfig) {
                 return Promise.resolve();
             }
 
+            // CASE: DB exists, but returns an unknown error
+            // e.g., providers like PlanetScale
+            const isDbExistsMisc =
+                err.errno == 1105 && 
+                err.sqlMessage.endsWith("database exists");
+        
+            if (isDbExistsMisc) {
+                return Promise.resolve();
+            }
+
             throw new errors.DatabaseError({
                 message: err.message,
                 err: err,

--- a/lib/database.js
+++ b/lib/database.js
@@ -135,7 +135,7 @@ exports.createDatabaseIfNotExist = function createDatabaseIfNotExist(dbConfig) {
             // e.g., providers like PlanetScale
             const isDbExistsMisc =
                 err.errno === 1105 && 
-                err.sqlMessage.endsWith("database exists");
+                err.sqlMessage.endsWith('database exists');
         
             if (isDbExistsMisc) {
                 return Promise.resolve();


### PR DESCRIPTION
no issue

- during database creation, the connection is expected to throw errno=1007 to know if initialization should be skipped.
- errors from some db providers, e.g. PlanetScale, are throwing as an unknown error (errno=1105)
  - this causes the initialization to crash when using these providers
- workaround is to add a special condition to catch errno=1105 with "database exists" message.
 - Detailed [exploration here for PlanetScale](https://justrox.me/ghost-blog-planet-scale/)