### PR TITLE
Fixed filename changed to loggingrc

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "bin",
     "lib",
     "migrations",
-    "logging.js"
+    "loggingrc.js"
   ],
   "devDependencies": {
     "eslint": "6.8.0",


### PR DESCRIPTION
ref https://github.com/TryGhost/knex-migrator/commit/4571d5433f29a31f37bdeef47d7003ce6c903546
- The file list in package.json was missed when the filename got changed from logging to loggingrc
- This changes it so that npm knows what files should be in the package