### PR TITLE
Used single quotes for SQL string literals for better compatibility

### DIFF
--- a/lib/database.js
+++ b/lib/database.js
@@ -180,7 +180,7 @@ exports.drop = function drop(options) {
     } else if (DatabaseInfo.isSQLite(connection)) {
         // @NOTE: sqlite3 does not support "DROP DATABASE". We have to drop each table instead.
         // @NOTE: We cannot just remove the sqlite3 file, because any database connection will get invalid.
-        return connection.raw('SELECT name FROM sqlite_master WHERE type="table";')
+        return connection.raw(`SELECT name FROM sqlite_master WHERE type='table';`)
             .then(function (tables) {
                 return sequence(tables.map(table => () => {
                     if (table.name === 'sqlite_sequence') {

--- a/test/assets/migrations/init/2-seed.js
+++ b/test/assets/migrations/init/2-seed.js
@@ -1,7 +1,7 @@
 module.exports.up = function insert(options) {
-    return options.connection.raw('INSERT INTO users (name) VALUES("Hausweib");');
+    return options.connection.raw(`INSERT INTO users (name) VALUES('Hausweib');`);
 };
 
 module.exports.down = function insert(options) {
-    return options.connection.raw('DELETE FROM users where name="Hausweib";');
+    return options.connection.raw(`DELETE FROM users where name='Hausweib';`);
 };

--- a/test/assets/migrations/versions/1.0/1-another.js
+++ b/test/assets/migrations/versions/1.0/1-another.js
@@ -1,7 +1,7 @@
 module.exports.up = function update(options) {
-    return options.connection.raw('UPDATE users set name="LULULU";');
+    return options.connection.raw(`UPDATE users set name='LULULU';`);
 };
 
 module.exports.down = function createTables(options) {
-    return options.connection.update('UPDATE users set name="Hausweib";');
+    return options.connection.update(`UPDATE users set name='Hausweib';`);
 };

--- a/test/assets/migrations_1/init/2-seed.js
+++ b/test/assets/migrations_1/init/2-seed.js
@@ -1,7 +1,7 @@
 module.exports.up = function createTables(options) {
-    return options.connection.raw('INSERT INTO users (name) VALUES("Hausweib");');
+    return options.connection.raw(`INSERT INTO users (name) VALUES('Hausweib');`);
 };
 
 module.exports.down = function createTables(options) {
-    return options.connection.raw('DELETE FROM users where name="Hausweib";');
+    return options.connection.raw(`DELETE FROM users where name='Hausweib';`);
 };

--- a/test/assets/migrations_2/init/2-seed.js
+++ b/test/assets/migrations_2/init/2-seed.js
@@ -1,7 +1,7 @@
 module.exports.up = function createTables(options) {
-    return options.connection.raw('INSERT INTO users (name) VALUES("Hausweib");');
+    return options.connection.raw(`INSERT INTO users (name) VALUES('Hausweib');`);
 };
 
 module.exports.up = function createTables(options) {
-    return options.connection.raw('DELETE FROM users where name="Hausweib";');
+    return options.connection.raw(`DELETE FROM users where name='Hausweib';`);
 };

--- a/test/assets/migrations_3/init/2-seed.js
+++ b/test/assets/migrations_3/init/2-seed.js
@@ -1,3 +1,3 @@
 module.exports.up = function createTables(options) {
-    return options.connection.raw('INSERT INTO users (name) VALUES("Hausweib");');
+    return options.connection.raw(`INSERT INTO users (name) VALUES('Hausweib');`);
 };

--- a/test/assets/migrations_3/init/3-fixtures.js
+++ b/test/assets/migrations_3/init/3-fixtures.js
@@ -1,3 +1,3 @@
 module.exports.up = function createTables(options) {
-    return options.connection.raw('INSERT INTO users (name) VALUES("Guido");');
+    return options.connection.raw(`INSERT INTO users (name) VALUES('Guido');`);
 };

--- a/test/assets/migrations_4/init/2-seed.js
+++ b/test/assets/migrations_4/init/2-seed.js
@@ -1,7 +1,7 @@
 module.exports.up = function createTables(options) {
-    return options.connection.raw('INSERT INTO users (name) VALUES("Hausweib");');
+    return options.connection.raw(`INSERT INTO users (name) VALUES('Hausweib');`);
 };
 
 module.exports.down = function createTables(options) {
-    return options.connection.raw('DELETE FROM users where name="Hausweib";');
+    return options.connection.raw(`DELETE FROM users where name='Hausweib';`);
 };

--- a/test/assets/migrations_4/versions/1.1/2-me.js
+++ b/test/assets/migrations_4/versions/1.1/2-me.js
@@ -1,7 +1,7 @@
 module.exports.up = function doesNothing(options) {
-    return options.connection.raw('INSERT INTO users (name, country) VALUES("Fun", "France");');
+    return options.connection.raw(`INSERT INTO users (name, country) VALUES('Fun', 'France');`);
 };
 
 module.exports.down = function doesNothing(options) {
-    return options.connection.raw('DELETE FROM users where name="Fun";');
+    return options.connection.raw(`DELETE FROM users where name='Fun';`);
 };

--- a/test/assets/migrations_4/versions/1.1/3-now.js
+++ b/test/assets/migrations_4/versions/1.1/3-now.js
@@ -1,7 +1,7 @@
 module.exports.up = function doesNothing(options) {
-    return options.connection.raw('INSERT INTO users (name) VALUES("James");');
+    return options.connection.raw(`INSERT INTO users (name) VALUES('James');`);
 };
 
 module.exports.down = function doesNothing(options) {
-    return options.connection.raw('DELETE FROM users where name="James";');
+    return options.connection.raw(`DELETE FROM users where name='James';`);
 };

--- a/test/assets/migrations_5/init/2-seed.js
+++ b/test/assets/migrations_5/init/2-seed.js
@@ -1,3 +1,3 @@
 module.exports.up = function createTables(options) {
-    return options.connection.raw('INSERT INTO users (name) VALUES("Hausweib");');
+    return options.connection.raw(`INSERT INTO users (name) VALUES('Hausweib');`);
 };

--- a/test/assets/migrations_5/versions/1.1/2-me.js
+++ b/test/assets/migrations_5/versions/1.1/2-me.js
@@ -1,3 +1,3 @@
 module.exports.up = function doesNothing(options) {
-    return options.connection.raw('INSERT INTO users (name, country) VALUES("Fun", "France");');
+    return options.connection.raw(`INSERT INTO users (name, country) VALUES('Fun', 'France');`);
 };

--- a/test/assets/migrations_5/versions/1.1/3-now.js
+++ b/test/assets/migrations_5/versions/1.1/3-now.js
@@ -1,3 +1,3 @@
 module.exports.up = function doesNothing(options) {
-    return options.connection.raw('INSERT INTO users (name) VALUES("James");');
+    return options.connection.raw(`INSERT INTO users (name) VALUES('James');`);
 };

--- a/test/assets/migrations_5/versions/1.2/2-boy.js
+++ b/test/assets/migrations_5/versions/1.2/2-boy.js
@@ -1,3 +1,3 @@
 module.exports.up = function doesSomething(options) {
-    return options.connection.raw('INSERT INTO dogs (type) VALUES("Zwergpudel");');
+    return options.connection.raw(`INSERT INTO dogs (type) VALUES('Zwergpudel');`);
 };

--- a/test/assets/migrations_6/init/2-seed.js
+++ b/test/assets/migrations_6/init/2-seed.js
@@ -1,7 +1,7 @@
 module.exports.up = function createTables(options) {
-    return options.connection.raw('INSERT INTO users (name) VALUES("Hausweib");');
+    return options.connection.raw(`INSERT INTO users (name) VALUES('Hausweib');`);
 };
 
 module.exports.up = function createTables(options) {
-    return options.connection.raw('DELETE FROM users where name="Hausweib";');
+    return options.connection.raw(`DELETE FROM users where name='Hausweib';`);
 };

--- a/test/assets/migrations_7/init/2-seed.js
+++ b/test/assets/migrations_7/init/2-seed.js
@@ -3,5 +3,5 @@ module.exports.up = function createTables() {
 };
 
 module.exports.down = function createTables(options) {
-    return options.connection.raw('DELETE FROM users where name="Hausweib";');
+    return options.connection.raw(`DELETE FROM users where name='Hausweib';`);
 };


### PR DESCRIPTION
## Summary

This PR fixes SQL syntax issues that prevent knex-migrator from working with `better-sqlite3`, which enforces stricter SQL standards than the original `sqlite3` package.

**The Issue:**
- In SQL, double quotes (`"`) are for identifiers (column/table names) - Single quotes (`'`) are for string literals
- The query `SELECT name FROM sqlite_master WHERE type="table"` incorrectly uses double quotes for the string literal `"table"`
- `better-sqlite3` enforces this distinction and rejects the query
 
**The Fix:**
- Changed `type="table"` to `type='table'` in `lib/database.js:183`
- Updated all test migration files to use proper SQL string literal syntax

**Related:**
- Unblocks TryGhost/Ghost#25556 (sqlite3 to better-sqlite3 migration)