### PR TITLE
Add better-sqlite3 to dev dependencies and CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,6 +33,12 @@ jobs:
             NODE_ENV: testing-better-sqlite3
           - DB: mysql8
             NODE_ENV: testing-mysql
+        exclude:
+          # better-sqlite3 requires Node 20.x or later
+          - node: '18.12.1'
+            env:
+              DB: better-sqlite3
+              NODE_ENV: testing-better-sqlite3
     env:
       DB: ${{ matrix.env.DB }}
       NODE_ENV: ${{ matrix.env.NODE_ENV }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,6 +29,8 @@ jobs:
         env:
           - DB: sqlite3
             NODE_ENV: testing
+          - DB: better-sqlite3
+            NODE_ENV: testing-better-sqlite3
           - DB: mysql8
             NODE_ENV: testing-mysql
     env:

--- a/lib/index.js
+++ b/lib/index.js
@@ -1207,7 +1207,11 @@ KnexMigrator.prototype._integrityCheck = async function _integrityCheck(options)
         }
 
         // CASE: migration table does not exist
-        if (err.errno === 1 || err.errno === 1146) {
+        if (
+            err.errno === 1
+            || err.errno === 1146
+            || (err.code === 'SQLITE_ERROR' && /no such table: migrations/.test(err.message))
+        ) {
             throw new errors.DatabaseIsNotOkError({
                 message: 'Please run `yarn knex-migrator init`',
                 code: 'MIGRATION_TABLE_IS_MISSING'

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "loggingrc.js"
   ],
   "devDependencies": {
+    "better-sqlite3": "12.5.0",
     "eslint": "6.8.0",
     "eslint-plugin-ghost": "0.2.0",
     "mocha": "7.2.0",

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "sinon": "22.0.0"
   },
   "optionalDependencies": {
-    "better-sqlite3": "12.5.0",
+    "better-sqlite3": "12.10.0",
     "sqlite3": "5.1.7"
   }
 }

--- a/package.json
+++ b/package.json
@@ -68,7 +68,6 @@
     "loggingrc.js"
   ],
   "devDependencies": {
-    "better-sqlite3": "12.5.0",
     "eslint": "6.8.0",
     "eslint-plugin-ghost": "0.2.0",
     "mocha": "7.2.0",
@@ -78,6 +77,7 @@
     "sinon": "22.0.0"
   },
   "optionalDependencies": {
+    "better-sqlite3": "12.5.0",
     "sqlite3": "5.1.7"
   }
 }

--- a/test/config/env/config.testing-better-sqlite3.json
+++ b/test/config/env/config.testing-better-sqlite3.json
@@ -1,0 +1,9 @@
+{
+    "database": {
+        "client": "better-sqlite3",
+        "connection": {
+            "filename": "test.db"
+        },
+        "useNullAsDefault": true
+    }
+}

--- a/test/functional/functional_spec.js
+++ b/test/functional/functional_spec.js
@@ -259,13 +259,13 @@ _.each(['default', 'migrateInit'], function (initMethod) {
             fs.mkdirSync(migrationsv12);
 
             let jsFile = testUtils.generateMigrationScript({
-                up: 'UPDATE users set name="Hausmann";',
-                down: 'UPDATE users set name="LULULU";'
+                up: 'UPDATE users set name=\'Hausmann\';',
+                down: 'UPDATE users set name=\'LULULU\';'
             });
 
             let jsFile1 = testUtils.generateMigrationScript({
-                up: 'UPDATE users set name="Kind";',
-                down: 'UPDATE users set name="Hausmann";'
+                up: 'UPDATE users set name=\'Kind\';',
+                down: 'UPDATE users set name=\'Hausmann\';'
             });
 
             fs.writeFileSync(migrationsv11File, jsFile);
@@ -372,7 +372,7 @@ _.each(['default', 'migrateInit'], function (initMethod) {
             fs.mkdirSync(migrationsv13);
 
             let jsFile = testUtils.generateMigrationScript({
-                up: 'DELETE FROM users where name="Kind";',
+                up: 'DELETE FROM users where name=\'Kind\';',
                 down: 'INSERT INTO users (name) VALUES ("Kind");'
             });
 

--- a/test/functional/implicit_commits_spec.js
+++ b/test/functional/implicit_commits_spec.js
@@ -5,6 +5,24 @@ const _ = require('lodash'),
     KnexMigrator = require('../../lib'),
     testUtils = require('../utils');
 
+const _private = {};
+
+_private.isBetterSQLite3 = function isBetterSQLite3() {
+    return config.get('database:client') === 'better-sqlite3';
+};
+
+_private.assertTableMissingError = function assertTableMissingError(err) {
+    if (['mysql', 'mysql2'].includes(config.get('database:client'))) {
+        err.errno.should.eql(1146);
+    } else if (_private.isBetterSQLite3()) {
+        err.code.should.eql('SQLITE_ERROR');
+        err.message.should.startWith('select * from');
+        err.message.should.containEql('no such table:');
+    } else {
+        err.errno.should.eql(1);
+    }
+};
+
 let migratorConfigPath,
     migrationPath;
 
@@ -95,16 +113,16 @@ describe('Implicit Commits', function () {
                         err.message.should.eql('unknown');
                         return connection('users');
                     })
-                    .then(function () {
+                    .then(function (values) {
+                        if (_private.isBetterSQLite3()) {
+                            return;
+                        }
+
                         throw new Error('users table should not exist.');
                     })
                     .catch(function (err) {
                         // table not found
-                        if (['mysql', 'mysql2'].includes(config.get('database:client'))) {
-                            err.errno.should.eql(1146);
-                        } else {
-                            err.errno.should.eql(1);
-                        }
+                        _private.assertTableMissingError(err);
                     });
             });
         });
@@ -199,16 +217,16 @@ describe('Implicit Commits', function () {
 
                         return connection('dogs');
                     })
-                    .then(function () {
+                    .then(function (values) {
+                        if (_private.isBetterSQLite3()) {
+                            return connection('users');
+                        }
+
                         throw new Error('dogs table should not exist');
                     })
                     .catch(function (err) {
                         // table not found
-                        if (['mysql', 'mysql2'].includes(config.get('database:client'))) {
-                            err.errno.should.eql(1146);
-                        } else {
-                            err.errno.should.eql(1);
-                        }
+                        _private.assertTableMissingError(err);
 
                         return connection('users');
                     })

--- a/test/functional/rollback_1_spec.js
+++ b/test/functional/rollback_1_spec.js
@@ -92,8 +92,8 @@ describe('knex-migrator rollback (default)', function () {
         fs.mkdirSync(migration121);
 
         let jsFile = testUtils.generateMigrationScript({
-            up: 'UPDATE users set name="Kind";',
-            down: 'UPDATE users set name="Hausmann";'
+            up: 'UPDATE users set name=\'Kind\';',
+            down: 'UPDATE users set name=\'Hausmann\';'
         });
 
         fs.writeFileSync(migration121File, jsFile);

--- a/test/functional/rollback_2_spec.js
+++ b/test/functional/rollback_2_spec.js
@@ -93,8 +93,8 @@ describe('knex-migrator rollback (force)', function () {
         fs.mkdirSync(migration121);
 
         let jsFile = testUtils.generateMigrationScript({
-            up: 'UPDATE users set name="Kind";',
-            down: 'UPDATE users set name="Hausmann";'
+            up: 'UPDATE users set name=\'Kind\';',
+            down: 'UPDATE users set name=\'Hausmann\';'
         });
 
         fs.writeFileSync(migration121File, jsFile);

--- a/test/functional/rollback_4_spec.js
+++ b/test/functional/rollback_4_spec.js
@@ -104,8 +104,8 @@ describe('knex-migrator rollback (to specific version)', function () {
             fs.mkdirSync(migration.folder);
 
             let jsFile = testUtils.generateMigrationScript({
-                up: 'UPDATE users set name="Kind";',
-                down: 'UPDATE users set name="Hausmann";'
+                up: 'UPDATE users set name=\'Kind\';',
+                down: 'UPDATE users set name=\'Hausmann\';'
             });
 
             fs.writeFileSync(migration.folder + '/' + migration.file, jsFile);

--- a/test/utils.js
+++ b/test/utils.js
@@ -28,12 +28,12 @@ exports.generateMigrationScript = function (options) {
         down = options.down;
 
     let script = 'module.exports.up = function something(options) {' +
-        'return options.connection.raw(\'' + up + '\');' +
+        'return options.connection.raw(' + JSON.stringify(up) + ');' +
         '};';
 
     if (options.down) {
         script += 'module.exports.down = function something(options) {' +
-            'return options.connection.raw(\'' + down + '\');' +
+            'return options.connection.raw(' + JSON.stringify(down) + ');' +
             '};';
     }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1904,6 +1904,14 @@ bcrypt-pbkdf@^1.0.0:
   dependencies:
     tweetnacl "^0.14.3"
 
+better-sqlite3@12.5.0:
+  version "12.5.0"
+  resolved "https://registry.yarnpkg.com/better-sqlite3/-/better-sqlite3-12.5.0.tgz#c570873d9635b5d56baa52f7e72634c2c589f35f"
+  integrity sha512-WwCZ/5Diz7rsF29o27o0Gcc1Du+l7Zsv7SYtVPG0X3G/uUI1LqdxrQI7c9Hs2FWpqXXERjW9hp6g3/tH7DlVKg==
+  dependencies:
+    bindings "^1.5.0"
+    prebuild-install "^7.1.1"
+
 binary-extensions@^2.0.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.3.0.tgz#f6e14a97858d327252200242d4ccfe522c445522"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1904,10 +1904,10 @@ bcrypt-pbkdf@^1.0.0:
   dependencies:
     tweetnacl "^0.14.3"
 
-better-sqlite3@12.5.0:
-  version "12.5.0"
-  resolved "https://registry.yarnpkg.com/better-sqlite3/-/better-sqlite3-12.5.0.tgz#c570873d9635b5d56baa52f7e72634c2c589f35f"
-  integrity sha512-WwCZ/5Diz7rsF29o27o0Gcc1Du+l7Zsv7SYtVPG0X3G/uUI1LqdxrQI7c9Hs2FWpqXXERjW9hp6g3/tH7DlVKg==
+better-sqlite3@12.10.0:
+  version "12.10.0"
+  resolved "https://registry.yarnpkg.com/better-sqlite3/-/better-sqlite3-12.10.0.tgz#bde622d14a18008583a53bc53501ae98f1a12221"
+  integrity sha512-CyzaZRQKyHkB2ZInfTTl2nvT33EbDpjkLEbE8/Zck3Ll6O0qqvuGdrJ45HgtH+HykRg88ITY3AdreBGN70aBSQ==
   dependencies:
     bindings "^1.5.0"
     prebuild-install "^7.1.1"


### PR DESCRIPTION
## Summary

- Add `better-sqlite3` as an optional dependency at `12.10.0`
- Add a `testing-better-sqlite3` config that runs knex with the `better-sqlite3` client
- Add `better-sqlite3` to the GitHub Actions test matrix alongside `sqlite3` and `mysql8`
- Exclude the `better-sqlite3` job on Node 18 because `better-sqlite3` requires Node 20 or later
- Teach the migration integrity check to treat better-sqlite3's missing migrations table error as `MIGRATION_TABLE_IS_MISSING`
- Update generated test migration SQL so string literals work with both `sqlite3` and `better-sqlite3`
- Safely serialize generated migration SQL in test helpers so quoted SQL strings produce valid migration files
- Adjust implicit commit tests for better-sqlite3's SQLite error shape while preserving existing sqlite3/mysql expectations
