### PR TITLE
Improve CI coverage enforcement

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -70,11 +70,13 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           path: knex-migrator
+          persist-credentials: false
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
           repository: TryGhost/Ghost
           path: Ghost
           fetch-depth: 0
+          persist-credentials: false
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: '22.18.0'
@@ -103,7 +105,10 @@ jobs:
     needs:
       - test
       - ghost-consumer-smoke
-    if: always()
+    if: >-
+      always() &&
+      (github.event_name == 'push' ||
+      (github.event_name == 'pull_request' && !startsWith(github.head_ref, 'renovate/')))
     steps:
       - name: Check required jobs
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,15 +62,48 @@ jobs:
       - run: yarn lint
       - run: yarn coverage
 
+  ghost-consumer-smoke:
+    name: Ghost consumer smoke
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' || (github.event_name == 'pull_request' && !startsWith(github.head_ref, 'renovate/'))
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          path: knex-migrator
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          repository: TryGhost/Ghost
+          path: Ghost
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: '22.18.0'
+      - name: Enable corepack
+        run: corepack enable
+      - name: Install knex-migrator dependencies
+        working-directory: knex-migrator
+        run: yarn --frozen-lockfile
+      - name: Install Ghost dependencies
+        working-directory: Ghost
+        run: pnpm install --frozen-lockfile --filter ghost...
+      - name: Run Ghost consumer smoke
+        working-directory: knex-migrator
+        env:
+          GHOST_CORE_PATH: ${{ github.workspace }}/Ghost/ghost/core
+        run: yarn smoke:ghost
+
   all-tests-pass:
     name: All tests pass
     runs-on: ubuntu-latest
     needs:
       - test
+      - ghost-consumer-smoke
     if: always()
     steps:
       - name: Check required jobs
         run: |
           if [[ "${{ needs.test.result }}" != "success" ]]; then
+            exit 1
+          fi
+          if [[ "${{ needs.ghost-consumer-smoke.result }}" != "success" ]]; then
             exit 1
           fi

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -74,6 +74,7 @@ jobs:
         with:
           repository: TryGhost/Ghost
           path: Ghost
+          fetch-depth: 0
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: '22.18.0'
@@ -85,10 +86,18 @@ jobs:
       - name: Install Ghost dependencies
         working-directory: Ghost
         run: pnpm install --frozen-lockfile --filter ghost...
+      - name: Link knex-migrator into Ghost
+        working-directory: knex-migrator
+        run: yarn link
+      - name: Use linked knex-migrator in Ghost
+        working-directory: Ghost/ghost/core
+        run: yarn link knex-migrator
       - name: Run Ghost consumer smoke
         working-directory: knex-migrator
         env:
-          GHOST_CORE_PATH: ${{ github.workspace }}/Ghost/ghost/core
+          GHOST_CORE_PATH: ${{ github.workspace }}/Ghost
+          KNEX_MIGRATOR_BIN: ${{ github.workspace }}/Ghost/ghost/core/node_modules/.bin/knex-migrator
+          KNEX_MIGRATOR_CWD: ${{ github.workspace }}/Ghost/ghost/core
         run: yarn smoke:ghost
 
   all-tests-pass:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,8 @@ on:
     branches:
       - main
       - 'renovate/*'
+permissions:
+  contents: read
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -56,5 +58,19 @@ jobs:
           echo "database__connection__host=127.0.0.1" >> $GITHUB_ENV
           echo "database__connection__port=${{ job.services.mysql.ports['3306'] }}" >> $GITHUB_ENV
 
-      - run: yarn
-      - run: yarn test
+      - run: yarn --frozen-lockfile
+      - run: yarn lint
+      - run: yarn coverage
+
+  all-tests-pass:
+    name: All tests pass
+    runs-on: ubuntu-latest
+    needs:
+      - test
+    if: always()
+    steps:
+      - name: Check required jobs
+        run: |
+          if [[ "${{ needs.test.result }}" != "success" ]]; then
+            exit 1
+          fi

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - 'renovate/*'
 permissions:
   contents: read
 jobs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -86,12 +86,9 @@ jobs:
       - name: Install Ghost dependencies
         working-directory: Ghost
         run: pnpm install --frozen-lockfile --filter ghost...
-      - name: Link knex-migrator into Ghost
-        working-directory: knex-migrator
-        run: yarn link
       - name: Use linked knex-migrator in Ghost
         working-directory: Ghost/ghost/core
-        run: yarn link knex-migrator
+        run: pnpm link ${{ github.workspace }}/knex-migrator
       - name: Run Ghost consumer smoke
         working-directory: knex-migrator
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,6 @@ permissions:
 jobs:
   test:
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' || (github.event_name == 'pull_request' && !startsWith(github.head_ref, 'renovate/'))
     services:
       mysql:
         image: ${{ matrix.env.DB == 'mysql8' && 'mysql:8.0' || '' }}
@@ -65,7 +64,6 @@ jobs:
   ghost-consumer-smoke:
     name: Ghost consumer smoke
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' || (github.event_name == 'pull_request' && !startsWith(github.head_ref, 'renovate/'))
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
@@ -105,10 +103,7 @@ jobs:
     needs:
       - test
       - ghost-consumer-smoke
-    if: >-
-      always() &&
-      (github.event_name == 'push' ||
-      (github.event_name == 'pull_request' && !startsWith(github.head_ref, 'renovate/')))
+    if: always()
     steps:
       - name: Check required jobs
         run: |

--- a/lib/database.js
+++ b/lib/database.js
@@ -1,9 +1,26 @@
-const knex = require('knex'),
+const path = require('path'),
+    bundledKnex = require('knex'),
     omit = require('lodash/omit'),
     debug = require('debug')('knex-migrator:database'),
     errors = require('./errors');
 const DatabaseInfo = require('@tryghost/database-info');
 const {sequence} = require('@tryghost/promise');
+
+function loadKnex(options) {
+    options = options || {};
+
+    if (options.knexModulePath) {
+        try {
+            return require(require.resolve('knex', {
+                paths: [path.resolve(options.knexModulePath)]
+            }));
+        } catch (err) {
+            debug('Could not load project knex from ' + options.knexModulePath + ': ' + err.message);
+        }
+    }
+
+    return bundledKnex;
+}
 
 /**
  * @NOTE: Knex-migrator only supports knex query builder.
@@ -11,7 +28,7 @@ const {sequence} = require('@tryghost/promise');
  * @param options
  * @returns {Knex.QueryBuilder | Knex}
  */
-exports.connect = function connect(options) {
+exports.connect = function connect(options, connectionOptions) {
     options = options || {};
 
     // Alias `mysql` to `mysql2` so we can maintain backwards compatibility
@@ -33,7 +50,7 @@ exports.connect = function connect(options) {
         delete options.connection.filename;
     }
 
-    return knex(options);
+    return loadKnex(connectionOptions)(options);
 };
 
 /**
@@ -101,7 +118,7 @@ exports.createMigrationsTable = async function createMigrationsTable(connection)
  * @param dbConfig
  * @returns {*}
  */
-exports.createDatabaseIfNotExist = function createDatabaseIfNotExist(dbConfig) {
+exports.createDatabaseIfNotExist = function createDatabaseIfNotExist(dbConfig, connectionOptions) {
     const name = dbConfig.connection.database,
         charset = dbConfig.connection.charset || 'utf8mb4';
 
@@ -117,7 +134,7 @@ exports.createDatabaseIfNotExist = function createDatabaseIfNotExist(dbConfig) {
     const connection = exports.connect({
         client: dbConfig.client,
         connection: omit(dbConfig.connection, ['database'])
-    });
+    }, connectionOptions);
 
     debug('Create database', name);
 

--- a/lib/database.js
+++ b/lib/database.js
@@ -10,12 +10,22 @@ function loadKnex(options) {
     options = options || {};
 
     if (options.knexModulePath) {
+        let resolvedKnexPath;
+
         try {
-            return require(require.resolve('knex', {
+            resolvedKnexPath = require.resolve('knex', {
                 paths: [path.resolve(options.knexModulePath)]
-            }));
+            });
         } catch (err) {
+            if (err.code !== 'MODULE_NOT_FOUND') {
+                throw err;
+            }
+
             debug('Could not load project knex from ' + options.knexModulePath + ': ' + err.message);
+        }
+
+        if (resolvedKnexPath) {
+            return require(resolvedKnexPath);
         }
     }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -35,6 +35,7 @@ function KnexMigrator(options = {}) {
     this.subfolder = config.subfolder || 'versions';
 
     this.dbConfig = config.database;
+    this.knexModulePath = options.knexMigratorFilePath || process.cwd();
 }
 
 /**
@@ -81,9 +82,9 @@ KnexMigrator.prototype.init = function init(options) {
         debug('No hooks found, no problem.');
     }
 
-    this.connection = database.connect(this.dbConfig);
+    this.connection = database.connect(this.dbConfig, {knexModulePath: this.knexModulePath});
 
-    return database.createDatabaseIfNotExist(self.dbConfig)
+    return database.createDatabaseIfNotExist(self.dbConfig, {knexModulePath: this.knexModulePath})
         .then(function () {
             if (noScripts) {
                 return;
@@ -320,7 +321,7 @@ KnexMigrator.prototype.migrate = async function migrate(options) {
         debug('No hooks found, no problem.');
     }
 
-    this.connection = database.connect(this.dbConfig);
+    this.connection = database.connect(this.dbConfig, {knexModulePath: this.knexModulePath});
 
     try {
         await database.ensureConnectionWorks(this.connection);
@@ -472,7 +473,7 @@ KnexMigrator.prototype.reset = function reset(options) {
     let self = this;
     let force = options.force;
 
-    this.connection = database.connect(this.dbConfig);
+    this.connection = database.connect(this.dbConfig, {knexModulePath: this.knexModulePath});
 
     // CASE: ignore lock completely and drop the db
     if (force) {
@@ -563,7 +564,7 @@ KnexMigrator.prototype.reset = function reset(options) {
  */
 KnexMigrator.prototype.isDatabaseOK = function isDatabaseOK() {
     let self = this;
-    this.connection = database.connect(this.dbConfig);
+    this.connection = database.connect(this.dbConfig, {knexModulePath: this.knexModulePath});
 
     return database.ensureConnectionWorks(this.connection)
         .then(function () {
@@ -653,7 +654,7 @@ KnexMigrator.prototype.rollback = function rollback(options) {
     let disableHooks = options.disableHooks;
     let hooks = {};
 
-    this.connection = database.connect(this.dbConfig);
+    this.connection = database.connect(this.dbConfig, {knexModulePath: this.knexModulePath});
 
     const helper = function helper() {
         return new Promise(function (resolve, reject) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -29,9 +29,11 @@ module.exports.loadConfig = function loadConfig(options) {
     }
 
     const knexMigratorFilePath = options.knexMigratorFilePath || process.cwd();
+    const configPath = path.join(path.resolve(knexMigratorFilePath), 'MigratorConfig.js');
+    let resolvedConfigPath;
 
     try {
-        return require(path.join(path.resolve(knexMigratorFilePath), '/MigratorConfig.js'));
+        resolvedConfigPath = require.resolve(configPath);
     } catch (err) {
         if (err.code === 'MODULE_NOT_FOUND') {
             throw new errors.KnexMigrateError({
@@ -40,6 +42,12 @@ module.exports.loadConfig = function loadConfig(options) {
             });
         }
 
+        throw new errors.KnexMigrateError({err: err});
+    }
+
+    try {
+        return require(resolvedConfigPath);
+    } catch (err) {
         throw new errors.KnexMigrateError({err: err});
     }
 };

--- a/package.json
+++ b/package.json
@@ -28,10 +28,10 @@
   "license": "MIT",
   "scripts": {
     "lint": "eslint --ext .js --cache lib/** test/**",
-    "test": "LEVEL=fatal _mocha --require test/utils.js --report lcovonly --exit -- test/**/*_spec.js",
+    "test": "LEVEL=fatal _mocha --require test/utils.js --exit -- test/**/*_spec.js",
     "test:unit": "yarn lint && LEVEL=fatal _mocha --require test/utils.js --report lcovonly -- test/unit/*_spec.js",
     "posttest": "yarn lint",
-    "coverage": "nyc --reporter=lcov _mocha --require test/utils.js -- test/*_spec.js",
+    "coverage": "nyc --check-coverage --lines 80 --functions 80 --branches 80 --reporter=text --reporter=lcov _mocha --require test/utils.js --exit -- test/**/*_spec.js",
     "preship": "yarn test",
     "ship": "STATUS=$(git status --porcelain); echo $STATUS; if [ -z \"$STATUS\" ]; then yarn publish && git push ${GHOST_UPSTREAM:-upstream} main --follow-tags; fi"
   },

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "lint": "eslint --ext .js --cache lib/** test/**",
     "test": "LEVEL=fatal _mocha --require test/utils.js --exit -- test/**/*_spec.js",
     "test:unit": "yarn lint && LEVEL=fatal _mocha --require test/utils.js --report lcovonly -- test/unit/*_spec.js",
+    "smoke:ghost": "node scripts/ghost-consumer-smoke.js",
     "posttest": "yarn lint",
     "coverage": "nyc --check-coverage --lines 80 --functions 80 --branches 80 --reporter=text --reporter=lcov _mocha --require test/utils.js --exit -- test/**/*_spec.js",
     "preship": "yarn test",

--- a/scripts/ghost-consumer-smoke.js
+++ b/scripts/ghost-consumer-smoke.js
@@ -51,7 +51,7 @@ function sortVersions(versions) {
 function runStep(name, args, env) {
     console.log('Running: ' + name);
 
-    const result = childProcess.spawnSync(process.execPath, [migratorBin].concat(args), {
+    const result = childProcess.spawnSync(migratorBin, args, {
         cwd: migratorCwd,
         env: env,
         encoding: 'utf8',

--- a/scripts/ghost-consumer-smoke.js
+++ b/scripts/ghost-consumer-smoke.js
@@ -1,0 +1,137 @@
+#!/usr/bin/env node
+
+const childProcess = require('child_process');
+const fs = require('fs');
+const {createRequire} = require('module');
+const os = require('os');
+const path = require('path');
+const compareVer = require('compare-ver');
+
+const repoRoot = path.resolve(__dirname, '..');
+const ghostCorePath = path.resolve(process.env.GHOST_CORE_PATH || process.argv[2] || path.join(repoRoot, '..', 'Ghost', 'ghost', 'core'));
+const migratorBin = path.join(repoRoot, 'bin', 'knex-migrator');
+const ghostPackagePath = path.join(ghostCorePath, 'package.json');
+const ghostRequire = createRequire(ghostPackagePath);
+
+function fail(message) {
+    console.error(message);
+    process.exit(1);
+}
+
+function requireFromGhost(moduleName) {
+    return ghostRequire(moduleName);
+}
+
+function sortVersions(versions) {
+    return versions.sort((left, right) => compareVer.gt(left, right));
+}
+
+function runStep(name, args, env) {
+    console.log('Running: ' + name);
+
+    const result = childProcess.spawnSync(process.execPath, [migratorBin].concat(args), {
+        cwd: repoRoot,
+        env: env,
+        encoding: 'utf8',
+        stdio: ['ignore', 'pipe', 'pipe']
+    });
+
+    if (result.stdout) {
+        process.stdout.write(result.stdout);
+    }
+
+    if (result.stderr) {
+        process.stderr.write(result.stderr);
+    }
+
+    if (result.status !== 0) {
+        fail(name + ' failed with exit code ' + result.status);
+    }
+}
+
+function getGhostVersion() {
+    const result = childProcess.spawnSync(process.execPath, [
+        '-e',
+        'process.stdout.write(require("@tryghost/version").safe);'
+    ], {
+        cwd: ghostCorePath,
+        encoding: 'utf8',
+        stdio: ['ignore', 'pipe', 'pipe']
+    });
+
+    if (result.status !== 0) {
+        if (result.stderr) {
+            process.stderr.write(result.stderr);
+        }
+
+        fail('Could not read Ghost version from ' + ghostCorePath);
+    }
+
+    return result.stdout.trim();
+}
+
+function getGhostVersions() {
+    const ghostVersion = getGhostVersion();
+    const versionsPath = path.join(ghostCorePath, 'core', 'server', 'data', 'migrations', 'versions');
+
+    const versions = sortVersions(fs.readdirSync(versionsPath).filter((entry) => {
+        return !entry.startsWith('.') && fs.statSync(path.join(versionsPath, entry)).isDirectory();
+    })).filter((version) => {
+        return compareVer.gt(version, ghostVersion) !== 1;
+    });
+
+    const currentVersion = versions[versions.length - 1];
+    const previousVersion = versions[versions.length - 2];
+
+    if (!currentVersion || !previousVersion) {
+        fail('Could not determine Ghost migration versions from ' + versionsPath);
+    }
+
+    return {
+        ghostVersion,
+        currentVersion,
+        previousVersion
+    };
+}
+
+function main() {
+    if (!fs.existsSync(ghostPackagePath)) {
+        fail('Ghost core package.json not found at ' + ghostPackagePath + '. Set GHOST_CORE_PATH to a Ghost core checkout.');
+    }
+
+    requireFromGhost('knex');
+
+    const versions = getGhostVersions();
+    const tempPath = fs.mkdtempSync(path.join(os.tmpdir(), 'knex-migrator-ghost-smoke-'));
+    const dbPath = path.join(tempPath, 'ghost-smoke.sqlite');
+    const contentPath = path.join(tempPath, 'content');
+
+    fs.mkdirSync(path.join(contentPath, 'data'), {recursive: true});
+
+    const env = Object.assign({}, process.env, {
+        NODE_ENV: 'testing',
+        database__connection__filename: dbPath,
+        paths__contentPath: contentPath
+    });
+
+    console.log('Ghost core: ' + ghostCorePath);
+    console.log('Ghost version: ' + versions.ghostVersion);
+    console.log('Rollback target: ' + versions.previousVersion);
+    console.log('Forward target: ' + versions.currentVersion);
+
+    try {
+        runStep('Ghost migrate --init', ['migrate', '--mgpath', ghostCorePath, '--init'], env);
+        runStep('Ghost health after init', ['health', '--mgpath', ghostCorePath], env);
+        runStep('Ghost rollback to ' + versions.previousVersion, ['rollback', '--mgpath', ghostCorePath, '--force', '--v', versions.previousVersion], env);
+        runStep('Ghost migrate to ' + versions.currentVersion, ['migrate', '--mgpath', ghostCorePath, '--v', versions.currentVersion, '--force'], env);
+        runStep('Ghost health after rollback/migrate', ['health', '--mgpath', ghostCorePath], env);
+    } finally {
+        if (!process.env.KEEP_GHOST_SMOKE_DB) {
+            fs.rmSync(tempPath, {recursive: true, force: true});
+        } else {
+            console.log('Kept smoke temp path: ' + tempPath);
+        }
+    }
+}
+
+main();

--- a/scripts/ghost-consumer-smoke.js
+++ b/scripts/ghost-consumer-smoke.js
@@ -8,8 +8,30 @@ const path = require('path');
 const compareVer = require('compare-ver');
 
 const repoRoot = path.resolve(__dirname, '..');
-const ghostCorePath = path.resolve(process.env.GHOST_CORE_PATH || process.argv[2] || path.join(repoRoot, '..', 'Ghost', 'ghost', 'core'));
-const migratorBin = path.join(repoRoot, 'bin', 'knex-migrator');
+const ghostPath = process.env.GHOST_CORE_PATH || process.argv[2] || path.join(repoRoot, '..', 'Ghost');
+const migratorBin = path.resolve(process.env.KNEX_MIGRATOR_BIN || path.join(repoRoot, 'bin', 'knex-migrator'));
+const migratorCwd = path.resolve(process.env.KNEX_MIGRATOR_CWD || (process.env.KNEX_MIGRATOR_BIN ? process.cwd() : repoRoot));
+
+function resolveGhostCorePath(inputPath) {
+    const resolvedPath = path.resolve(inputPath);
+    const candidates = [
+        resolvedPath,
+        path.join(resolvedPath, 'ghost', 'core')
+    ];
+
+    const corePath = candidates.find((candidatePath) => {
+        return fs.existsSync(path.join(candidatePath, 'package.json'))
+            && fs.existsSync(path.join(candidatePath, 'MigratorConfig.js'));
+    });
+
+    if (!corePath) {
+        fail('Ghost core package.json not found from ' + resolvedPath + '. Set GHOST_CORE_PATH to a Ghost repository or Ghost core checkout.');
+    }
+
+    return corePath;
+}
+
+const ghostCorePath = resolveGhostCorePath(ghostPath);
 const ghostPackagePath = path.join(ghostCorePath, 'package.json');
 const ghostRequire = createRequire(ghostPackagePath);
 
@@ -30,7 +52,7 @@ function runStep(name, args, env) {
     console.log('Running: ' + name);
 
     const result = childProcess.spawnSync(process.execPath, [migratorBin].concat(args), {
-        cwd: repoRoot,
+        cwd: migratorCwd,
         env: env,
         encoding: 'utf8',
         stdio: ['ignore', 'pipe', 'pipe']
@@ -95,8 +117,8 @@ function getGhostVersions() {
 }
 
 function main() {
-    if (!fs.existsSync(ghostPackagePath)) {
-        fail('Ghost core package.json not found at ' + ghostPackagePath + '. Set GHOST_CORE_PATH to a Ghost core checkout.');
+    if (!fs.existsSync(migratorBin)) {
+        fail('knex-migrator bin not found at ' + migratorBin + '. Set KNEX_MIGRATOR_BIN to the linked package bin.');
     }
 
     requireFromGhost('knex');
@@ -115,6 +137,8 @@ function main() {
     });
 
     console.log('Ghost core: ' + ghostCorePath);
+    console.log('knex-migrator bin: ' + migratorBin);
+    console.log('knex-migrator cwd: ' + migratorCwd);
     console.log('Ghost version: ' + versions.ghostVersion);
     console.log('Rollback target: ' + versions.previousVersion);
     console.log('Forward target: ' + versions.currentVersion);

--- a/test/unit/_rollback_spec.js
+++ b/test/unit/_rollback_spec.js
@@ -276,4 +276,109 @@ describe('Unit: _rollback', function () {
             tasks[2].down.called.should.eql(false);
         });
     });
+
+    it('skips requested rollback tasks', function () {
+        const knexMigrator = new KnexMigrator({
+            knexMigratorConfig: {
+                database: {},
+                migrationPath: 'location',
+                currentVersion: '1.9'
+            }
+        });
+
+        knexMigrator.connection = sinon.stub().returns({
+            where: sinon.stub().returns({
+                delete: sinon.stub().resolves()
+            })
+        });
+
+        const tasks = [
+            {
+                up: sinon.stub(),
+                down: sinon.stub().resolves(),
+                name: '1-something'
+            }
+        ];
+
+        sinon.stub(utils, 'readTasks').returns(tasks);
+
+        return knexMigrator._rollback({
+            version: '1.10',
+            skippedTasks: {
+                '1.10': ['1-something']
+            }
+        }).then(function () {
+            tasks[0].down.called.should.eql(false);
+        });
+    });
+
+    it('limits rollback to selected tasks', function () {
+        const knexMigrator = new KnexMigrator({
+            knexMigratorConfig: {
+                database: {},
+                migrationPath: 'location',
+                currentVersion: '1.9'
+            }
+        });
+
+        knexMigrator.connection = sinon.stub().returns({
+            where: sinon.stub().returns({
+                delete: sinon.stub().resolves()
+            })
+        });
+
+        const tasks = [
+            {
+                up: sinon.stub(),
+                down: sinon.stub().resolves(),
+                name: '1-something'
+            }
+        ];
+
+        sinon.stub(utils, 'readTasks').returns(tasks);
+
+        return knexMigrator._rollback({
+            version: '1.10',
+            onlyTasks: ['2-something']
+        }).then(function () {
+            tasks[0].down.called.should.eql(false);
+        });
+    });
+
+    it('rolls back transaction-enabled tasks inside a transaction', function () {
+        const knexMigrator = new KnexMigrator({
+            knexMigratorConfig: {
+                database: {},
+                migrationPath: 'location',
+                currentVersion: '1.9'
+            }
+        });
+
+        knexMigrator.connection = sinon.stub().returns({
+            where: sinon.stub().returns({
+                delete: sinon.stub().resolves()
+            })
+        });
+
+        const txn = {};
+        const task = {
+            config: {
+                transaction: true
+            },
+            up: sinon.stub(),
+            down: sinon.stub().resolves(),
+            name: '1-something'
+        };
+
+        sinon.stub(utils, 'readTasks').returns([task]);
+        sinon.stub(require('../../lib/database'), 'createTransaction').callsFake(function (connection, callback) {
+            return callback(txn);
+        });
+
+        return knexMigrator._rollback({
+            version: '1.10'
+        }).then(function () {
+            task.down.calledWith({transacting: txn}).should.eql(true);
+        });
+    });
 });

--- a/test/unit/database_spec.js
+++ b/test/unit/database_spec.js
@@ -1,5 +1,8 @@
 const should = require('should');
 const sinon = require('sinon');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
 
 const database = require('../../lib/database');
 const errors = require('../../lib/errors');
@@ -39,6 +42,38 @@ describe('Database', function () {
             connection.client.config.useNullAsDefault.should.eql(true);
 
             return connection.destroy();
+        });
+
+        it('prefers a project-local knex module when a project path is provided', function () {
+            const projectPath = fs.mkdtempSync(path.join(os.tmpdir(), 'knex-migrator-project-knex-'));
+            const knexPath = path.join(projectPath, 'node_modules', 'knex');
+
+            fs.mkdirSync(knexPath, {recursive: true});
+            fs.writeFileSync(path.join(knexPath, 'index.js'), [
+                'module.exports = function knex(options) {',
+                '  return {',
+                '    client: {config: options},',
+                '    loadedFromProject: true',
+                '  };',
+                '};',
+                ''
+            ].join('\n'));
+
+            try {
+                const connection = database.connect({
+                    client: 'sqlite3',
+                    connection: {
+                        filename: ':memory:'
+                    }
+                }, {
+                    knexModulePath: projectPath
+                });
+
+                connection.loadedFromProject.should.eql(true);
+                connection.client.config.client.should.eql('sqlite3');
+            } finally {
+                fs.rmSync(projectPath, {recursive: true, force: true});
+            }
         });
     });
 

--- a/test/unit/database_spec.js
+++ b/test/unit/database_spec.js
@@ -1,0 +1,304 @@
+const should = require('should');
+const sinon = require('sinon');
+
+const database = require('../../lib/database');
+const errors = require('../../lib/errors');
+
+describe('Database', function () {
+    afterEach(function () {
+        sinon.restore();
+    });
+
+    describe('connect', function () {
+        it('aliases mysql configs to mysql2 defaults', function () {
+            const connection = database.connect({
+                client: 'mysql',
+                connection: {
+                    filename: 'unused.db'
+                }
+            });
+
+            connection.client.config.client.should.eql('mysql2');
+            connection.client.config.connection.timezone.should.eql('Z');
+            connection.client.config.connection.charset.should.eql('utf8mb4');
+            connection.client.config.connection.decimalNumbers.should.eql(true);
+            should.not.exist(connection.client.config.connection.filename);
+
+            return connection.destroy();
+        });
+
+        it('preserves explicit sqlite useNullAsDefault', function () {
+            const connection = database.connect({
+                client: 'sqlite3',
+                connection: {
+                    filename: ':memory:'
+                },
+                useNullAsDefault: true
+            });
+
+            connection.client.config.useNullAsDefault.should.eql(true);
+
+            return connection.destroy();
+        });
+    });
+
+    describe('ensureConnectionWorks', function () {
+        it('wraps temporary DNS errors with database config help', function () {
+            const err = new Error('temporary lookup failure');
+            err.code = 'EAI_AGAIN';
+
+            return database.ensureConnectionWorks({
+                raw: sinon.stub().rejects(err)
+            }).then(function () {
+                true.should.eql(false);
+            }).catch(function (wrappedErr) {
+                wrappedErr.should.be.instanceof(errors.DatabaseError);
+                wrappedErr.message.should.eql('Invalid database host.');
+                wrappedErr.help.should.eql('Please double check your database config.');
+            });
+        });
+
+        it('wraps unknown connection failures', function () {
+            return database.ensureConnectionWorks({
+                raw: sinon.stub().rejects(new Error('permission denied'))
+            }).then(function () {
+                true.should.eql(false);
+            }).catch(function (wrappedErr) {
+                wrappedErr.should.be.instanceof(errors.DatabaseError);
+                wrappedErr.message.should.eql('permission denied');
+                wrappedErr.help.should.eql('Unknown database error');
+            });
+        });
+    });
+
+    describe('createMigrationsTable', function () {
+        it('does nothing when the migrations table already exists', function () {
+            const createTable = sinon.stub();
+
+            return database.createMigrationsTable({
+                schema: {
+                    hasTable: sinon.stub().resolves(true),
+                    createTable: createTable
+                }
+            }).then(function () {
+                createTable.called.should.eql(false);
+            });
+        });
+    });
+
+    describe('createDatabaseIfNotExist', function () {
+        it('rejects unsupported database clients', function () {
+            return database.createDatabaseIfNotExist({
+                client: 'postgres',
+                connection: {
+                    database: 'km_testing'
+                }
+            }).then(function () {
+                true.should.eql(false);
+            }).catch(function (err) {
+                err.should.be.instanceof(errors.KnexMigrateError);
+                err.message.should.eql('Database is not supported.');
+            });
+        });
+
+        it('ignores existing mysql databases', function () {
+            const connection = {
+                raw: sinon.stub().rejects({errno: 1007}),
+                destroy: sinon.stub().callsArg(0)
+            };
+
+            sinon.stub(database, 'connect').returns(connection);
+            sinon.stub(database, 'ensureConnectionWorks').resolves();
+
+            return database.createDatabaseIfNotExist({
+                client: 'mysql2',
+                connection: {
+                    database: 'km_testing'
+                }
+            }).then(function () {
+                connection.destroy.calledOnce.should.eql(true);
+            });
+        });
+
+        it('rejects destroy failures after mysql database creation', function () {
+            const connection = {
+                raw: sinon.stub().resolves(),
+                destroy: sinon.stub().callsArgWith(0, new Error('destroy failed'))
+            };
+
+            sinon.stub(database, 'connect').returns(connection);
+            sinon.stub(database, 'ensureConnectionWorks').resolves();
+
+            return database.createDatabaseIfNotExist({
+                client: 'mysql2',
+                connection: {
+                    database: 'km_testing'
+                }
+            }).then(function () {
+                true.should.eql(false);
+            }).catch(function (err) {
+                err.message.should.eql('destroy failed');
+            });
+        });
+    });
+
+    describe('drop', function () {
+        it('ignores missing mysql databases', function () {
+            return database.drop({
+                dbConfig: {
+                    connection: {
+                        database: 'km_testing'
+                    }
+                },
+                connection: {
+                    client: {
+                        config: {
+                            client: 'mysql2'
+                        }
+                    },
+                    raw: sinon.stub().rejects({errno: 1049})
+                }
+            });
+        });
+
+        it('wraps mysql drop failures', function () {
+            return database.drop({
+                dbConfig: {
+                    connection: {
+                        database: 'km_testing'
+                    }
+                },
+                connection: {
+                    client: {
+                        config: {
+                            client: 'mysql2'
+                        }
+                    },
+                    raw: sinon.stub().rejects(new Error('permission denied'))
+                }
+            }).then(function () {
+                true.should.eql(false);
+            }).catch(function (err) {
+                err.should.be.instanceof(errors.KnexMigrateError);
+            });
+        });
+
+        it('drops sqlite tables and skips sqlite_sequence', function () {
+            const dropTableIfExists = sinon.stub().resolves();
+            const connection = {
+                client: {
+                    config: {
+                        client: 'sqlite3'
+                    }
+                },
+                raw: sinon.stub().resolves([
+                    {name: 'sqlite_sequence'},
+                    {name: 'migrations'}
+                ]),
+                schema: {
+                    dropTableIfExists: dropTableIfExists
+                }
+            };
+
+            return database.drop({
+                dbConfig: {
+                    client: 'sqlite3'
+                },
+                connection: connection
+            }).then(function () {
+                dropTableIfExists.calledOnceWith('migrations').should.eql(true);
+            });
+        });
+
+        it('restores better-sqlite foreign keys after dropping tables', function () {
+            const raw = sinon.stub();
+            raw.onFirstCall().resolves();
+            raw.onSecondCall().resolves([{name: 'migrations'}]);
+            raw.onThirdCall().resolves();
+
+            const connection = {
+                client: {
+                    config: {
+                        client: 'better-sqlite3'
+                    }
+                },
+                raw: raw,
+                schema: {
+                    dropTableIfExists: sinon.stub().resolves()
+                }
+            };
+
+            return database.drop({
+                dbConfig: {
+                    client: 'better-sqlite3'
+                },
+                connection: connection
+            }).then(function () {
+                raw.firstCall.calledWith('PRAGMA foreign_keys = OFF;').should.eql(true);
+                raw.thirdCall.calledWith('PRAGMA foreign_keys = ON;').should.eql(true);
+            });
+        });
+
+        it('ignores uninitialized sqlite databases', function () {
+            return database.drop({
+                dbConfig: {
+                    client: 'sqlite3'
+                },
+                connection: {
+                    client: {
+                        config: {
+                            client: 'sqlite3'
+                        }
+                    },
+                    raw: sinon.stub().rejects({errno: 10}),
+                    schema: {
+                        dropTableIfExists: sinon.stub()
+                    }
+                }
+            });
+        });
+
+        it('wraps sqlite drop failures', function () {
+            return database.drop({
+                dbConfig: {
+                    client: 'sqlite3'
+                },
+                connection: {
+                    client: {
+                        config: {
+                            client: 'sqlite3'
+                        }
+                    },
+                    raw: sinon.stub().rejects(new Error('drop failed')),
+                    schema: {
+                        dropTableIfExists: sinon.stub()
+                    }
+                }
+            }).then(function () {
+                true.should.eql(false);
+            }).catch(function (err) {
+                err.should.be.instanceof(errors.KnexMigrateError);
+            });
+        });
+
+        it('rejects unsupported database clients', function () {
+            return database.drop({
+                dbConfig: {
+                    client: 'postgres'
+                },
+                connection: {
+                    client: {
+                        config: {
+                            client: 'postgres'
+                        }
+                    }
+                }
+            }).then(function () {
+                true.should.eql(false);
+            }).catch(function (err) {
+                err.should.be.instanceof(errors.KnexMigrateError);
+                err.message.should.eql('Database client not supported: postgres');
+            });
+        });
+    });
+});

--- a/test/unit/database_spec.js
+++ b/test/unit/database_spec.js
@@ -75,6 +75,29 @@ describe('Database', function () {
                 fs.rmSync(projectPath, {recursive: true, force: true});
             }
         });
+
+        it('throws project-local knex load errors', function () {
+            const projectPath = fs.mkdtempSync(path.join(os.tmpdir(), 'knex-migrator-broken-project-knex-'));
+            const knexPath = path.join(projectPath, 'node_modules', 'knex');
+
+            fs.mkdirSync(knexPath, {recursive: true});
+            fs.writeFileSync(path.join(knexPath, 'index.js'), 'throw new Error("broken project knex");\n');
+
+            try {
+                (function () {
+                    database.connect({
+                        client: 'sqlite3',
+                        connection: {
+                            filename: ':memory:'
+                        }
+                    }, {
+                        knexModulePath: projectPath
+                    });
+                }).should.throw('broken project knex');
+            } finally {
+                fs.rmSync(projectPath, {recursive: true, force: true});
+            }
+        });
     });
 
     describe('ensureConnectionWorks', function () {

--- a/test/unit/fixtures/broken-config/MigratorConfig.js
+++ b/test/unit/fixtures/broken-config/MigratorConfig.js
@@ -1,0 +1,3 @@
+require('missing-config-dependency');
+
+module.exports = {};

--- a/test/unit/index_spec.js
+++ b/test/unit/index_spec.js
@@ -1,0 +1,276 @@
+const path = require('path');
+const sinon = require('sinon');
+
+const database = require('../../lib/database');
+const errors = require('../../lib/errors');
+const KnexMigrator = require('../../lib');
+const utils = require('../../lib/utils');
+
+function createKnexMigrator() {
+    return new KnexMigrator({
+        knexMigratorConfig: {
+            database: {},
+            migrationPath: path.join(__dirname, '..', 'assets', 'migrations'),
+            currentVersion: '1.0'
+        }
+    });
+}
+
+function createDeleteChain() {
+    return {
+        where: sinon.stub().returns({
+            delete: sinon.stub().resolves()
+        })
+    };
+}
+
+describe('KnexMigrator', function () {
+    afterEach(function () {
+        sinon.restore();
+    });
+
+    it('requires a database config', function () {
+        try {
+            new KnexMigrator({
+                knexMigratorConfig: {
+                    migrationPath: 'migrations',
+                    currentVersion: '1.0'
+                }
+            });
+            true.should.eql(false);
+        } catch (err) {
+            err.message.should.eql('MigratorConfig.js needs to export a database config.');
+        }
+    });
+
+    it('requires a migration path', function () {
+        try {
+            new KnexMigrator({
+                knexMigratorConfig: {
+                    database: {},
+                    currentVersion: '1.0'
+                }
+            });
+            true.should.eql(false);
+        } catch (err) {
+            err.message.should.eql('MigratorConfig.js needs to export the location of your migration files.');
+        }
+    });
+
+    it('requires a current version', function () {
+        try {
+            new KnexMigrator({
+                knexMigratorConfig: {
+                    database: {},
+                    migrationPath: 'migrations'
+                }
+            });
+            true.should.eql(false);
+        } catch (err) {
+            err.message.should.eql('MigratorConfig.js needs to export the a current version.');
+        }
+    });
+
+    describe('_beforeEach', function () {
+        it('allows the first migration when no migrations are stored', function () {
+            const knexMigrator = createKnexMigrator();
+            knexMigrator.connection = sinon.stub().resolves([]);
+
+            return knexMigrator._beforeEach({
+                task: '1-test.js',
+                version: '1.0'
+            });
+        });
+
+        it('rejects duplicate migrations', function () {
+            const knexMigrator = createKnexMigrator();
+            knexMigrator.connection = sinon.stub().resolves([{name: '1-test.js', version: '1.0'}]);
+
+            return knexMigrator._beforeEach({
+                task: '1-test.js',
+                version: '1.0'
+            }).then(function () {
+                true.should.eql(false);
+            }).catch(function (err) {
+                err.should.be.instanceof(errors.MigrationExistsError);
+            });
+        });
+    });
+
+    describe('_migrateTo', function () {
+        it('runs transactional tasks and hooks', function () {
+            const knexMigrator = createKnexMigrator();
+            knexMigrator.connection = createDeleteChain;
+
+            const task = {
+                name: '1-test.js',
+                config: {
+                    transaction: true
+                },
+                up: sinon.stub().resolves()
+            };
+            const txn = {};
+
+            sinon.stub(utils, 'readTasks').returns([task]);
+            sinon.stub(knexMigrator, '_beforeEach').resolves();
+            sinon.stub(knexMigrator, '_afterEach').resolves();
+            sinon.stub(database, 'createTransaction').callsFake(function (connection, callback) {
+                return callback(txn);
+            });
+
+            const hooks = {
+                beforeEach: sinon.stub().resolves(),
+                afterEach: sinon.stub().resolves()
+            };
+
+            return knexMigrator._migrateTo({
+                version: '1.0',
+                hooks: hooks
+            }).then(function (result) {
+                result.skippedTasks.should.eql([]);
+                hooks.beforeEach.calledOnce.should.eql(true);
+                hooks.afterEach.calledOnce.should.eql(true);
+                task.up.calledWith({transacting: txn}).should.eql(true);
+            });
+        });
+
+        it('skips existing migrations', function () {
+            const knexMigrator = createKnexMigrator();
+            knexMigrator.connection = createDeleteChain;
+
+            sinon.stub(utils, 'readTasks').returns([{
+                name: '1-test.js',
+                up: sinon.stub().resolves()
+            }]);
+            sinon.stub(knexMigrator, '_beforeEach').rejects(new errors.MigrationExistsError());
+
+            return knexMigrator._migrateTo({
+                version: '1.0'
+            }).then(function (result) {
+                result.skippedTasks.should.eql(['1-test.js']);
+            });
+        });
+
+        it('wraps long key errors with field-length guidance', function () {
+            const knexMigrator = createKnexMigrator();
+            knexMigrator.connection = createDeleteChain;
+
+            const err = new Error('Key column `table_name`.`field_name` is too long');
+            err.code = 'ER_TOO_LONG_KEY';
+
+            sinon.stub(utils, 'readTasks').returns([{
+                name: '1-test.js',
+                up: sinon.stub().rejects(err)
+            }]);
+            sinon.stub(knexMigrator, '_beforeEach').resolves();
+
+            return knexMigrator._migrateTo({
+                version: '1.0'
+            }).then(function () {
+                true.should.eql(false);
+            }).catch(function (wrappedErr) {
+                wrappedErr.should.be.instanceof(errors.MigrationScriptError);
+                wrappedErr.message.should.match(/Field length/);
+            });
+        });
+
+        it('runs only the requested task when only is set', function () {
+            const knexMigrator = createKnexMigrator();
+            knexMigrator.connection = createDeleteChain;
+
+            const skippedTask = {
+                name: '1-test.js',
+                up: sinon.stub().resolves()
+            };
+            const selectedTask = {
+                name: '2-test.js',
+                up: sinon.stub().resolves()
+            };
+
+            sinon.stub(utils, 'readTasks').returns([skippedTask, selectedTask]);
+            sinon.stub(knexMigrator, '_beforeEach').resolves();
+            sinon.stub(knexMigrator, '_afterEach').resolves();
+
+            return knexMigrator._migrateTo({
+                version: '1.0',
+                only: 2
+            }).then(function () {
+                skippedTask.up.called.should.eql(false);
+                selectedTask.up.calledOnce.should.eql(true);
+            });
+        });
+
+        it('skips the requested task when skip is set', function () {
+            const knexMigrator = createKnexMigrator();
+            knexMigrator.connection = createDeleteChain;
+
+            const skippedTask = {
+                name: '1-test.js',
+                up: sinon.stub().resolves()
+            };
+            const selectedTask = {
+                name: '2-test.js',
+                up: sinon.stub().resolves()
+            };
+
+            sinon.stub(utils, 'readTasks').returns([skippedTask, selectedTask]);
+            sinon.stub(knexMigrator, '_beforeEach').resolves();
+            sinon.stub(knexMigrator, '_afterEach').resolves();
+
+            return knexMigrator._migrateTo({
+                version: '1.0',
+                skip: 1
+            }).then(function () {
+                skippedTask.up.called.should.eql(false);
+                selectedTask.up.calledOnce.should.eql(true);
+            });
+        });
+    });
+
+    describe('_integrityCheck', function () {
+        it('reports a missing target database', function () {
+            const knexMigrator = createKnexMigrator();
+            knexMigrator.connection = sinon.stub().returns({
+                select: sinon.stub().throws({errno: 1046})
+            });
+
+            return knexMigrator._integrityCheck({}).then(function () {
+                true.should.eql(false);
+            }).catch(function (err) {
+                err.should.be.instanceof(errors.DatabaseIsNotOkError);
+                err.code.should.eql('DB_NOT_INITIALISED');
+            });
+        });
+
+        it('reports a missing migrations table', function () {
+            const knexMigrator = createKnexMigrator();
+            knexMigrator.connection = sinon.stub().returns({
+                select: sinon.stub().throws({
+                    code: 'SQLITE_ERROR',
+                    message: 'no such table: migrations'
+                })
+            });
+
+            return knexMigrator._integrityCheck({}).then(function () {
+                true.should.eql(false);
+            }).catch(function (err) {
+                err.should.be.instanceof(errors.DatabaseIsNotOkError);
+                err.code.should.eql('MIGRATION_TABLE_IS_MISSING');
+            });
+        });
+
+        it('reports a missing mysql database', function () {
+            const knexMigrator = createKnexMigrator();
+            knexMigrator.connection = sinon.stub().returns({
+                select: sinon.stub().throws({errno: 1049})
+            });
+
+            return knexMigrator._integrityCheck({}).then(function () {
+                true.should.eql(false);
+            }).catch(function (err) {
+                err.should.be.instanceof(errors.DatabaseIsNotOkError);
+                err.code.should.eql('DB_NOT_INITIALISED');
+            });
+        });
+    });
+});

--- a/test/unit/index_spec.js
+++ b/test/unit/index_spec.js
@@ -155,7 +155,7 @@ describe('KnexMigrator', function () {
             const knexMigrator = createKnexMigrator();
             knexMigrator.connection = createDeleteChain;
 
-            const err = new Error('Key column `table_name`.`field_name` is too long');
+            const err = new Error('Specified key was too long for index `table_name`.`idx_name`.`field_name`');
             err.code = 'ER_TOO_LONG_KEY';
 
             sinon.stub(utils, 'readTasks').returns([{
@@ -170,7 +170,7 @@ describe('KnexMigrator', function () {
                 true.should.eql(false);
             }).catch(function (wrappedErr) {
                 wrappedErr.should.be.instanceof(errors.MigrationScriptError);
-                wrappedErr.message.should.match(/Field length/);
+                wrappedErr.message.should.eql('Field length of `field_name` in `table_name` is too long!');
             });
         });
 

--- a/test/unit/locking_spec.js
+++ b/test/unit/locking_spec.js
@@ -1,0 +1,113 @@
+const sinon = require('sinon');
+
+const database = require('../../lib/database');
+const errors = require('../../lib/errors');
+const locking = require('../../lib/locking');
+
+function createLockTable(data) {
+    return function lockTable() {
+        return {
+            where: sinon.stub().returns({
+                forUpdate: sinon.stub().returns({
+                    then: function (callback) {
+                        return Promise.resolve(data).then(callback);
+                    }
+                })
+            })
+        };
+    };
+}
+
+function createRejectedLockTable(err) {
+    return function lockTable() {
+        return {
+            where: sinon.stub().returns({
+                forUpdate: sinon.stub().returns(Promise.reject(err))
+            })
+        };
+    };
+}
+
+describe('Locking', function () {
+    afterEach(function () {
+        sinon.restore();
+    });
+
+    describe('lock', function () {
+        it('rejects when the migration lock row is missing', function () {
+            sinon.stub(database, 'createTransaction').callsFake(function (connection, callback) {
+                return callback(createLockTable([]));
+            });
+
+            return locking.lock({}).then(function () {
+                true.should.eql(false);
+            }).catch(function (err) {
+                err.should.be.instanceof(errors.MigrationsAreLockedError);
+            });
+        });
+
+        it('wraps unexpected lock acquisition errors', function () {
+            sinon.stub(database, 'createTransaction').callsFake(function (connection, callback) {
+                return callback(createRejectedLockTable(new Error('driver failed')));
+            });
+
+            return locking.lock({}).then(function () {
+                true.should.eql(false);
+            }).catch(function (err) {
+                err.should.be.instanceof(errors.LockError);
+                err.message.should.eql('Error while acquire the migration lock.');
+            });
+        });
+    });
+
+    describe('isLocked', function () {
+        it('returns false when the lock is released', function () {
+            const connection = sinon.stub().returns({
+                where: sinon.stub().resolves([{locked: 0}])
+            });
+
+            return locking.isLocked(connection).then(function (result) {
+                result.should.eql(false);
+            });
+        });
+
+        it('rejects when the lock row is locked', function () {
+            const connection = sinon.stub().returns({
+                where: sinon.stub().resolves([{locked: 1}])
+            });
+
+            return locking.isLocked(connection).then(function () {
+                true.should.eql(false);
+            }).catch(function (err) {
+                err.should.be.instanceof(errors.MigrationsAreLockedError);
+            });
+        });
+    });
+
+    describe('unlock', function () {
+        it('rejects when the migration lock row is already released', function () {
+            sinon.stub(database, 'createTransaction').callsFake(function (connection, callback) {
+                return callback(createLockTable([{locked: 0}]));
+            });
+
+            return locking.unlock({}).then(function () {
+                true.should.eql(false);
+            }).catch(function (err) {
+                err.should.be.instanceof(errors.MigrationsAreLockedError);
+            });
+        });
+
+        it('wraps unexpected unlock errors', function () {
+            sinon.stub(database, 'createTransaction').callsFake(function (connection, callback) {
+                return callback(createRejectedLockTable(new Error('driver failed')));
+            });
+
+            return locking.unlock({}).then(function () {
+                true.should.eql(false);
+            }).catch(function (err) {
+                err.should.be.instanceof(errors.UnlockError);
+                err.message.should.eql('Error while releasing the migration lock.');
+            });
+        });
+    });
+});

--- a/test/unit/migrations_spec.js
+++ b/test/unit/migrations_spec.js
@@ -1,0 +1,118 @@
+const sinon = require('sinon');
+
+const addPrimaryKeyToLockTable = require('../../migrations/add-primary-key-to-lock-table');
+const lockTable = require('../../migrations/lock-table');
+
+describe('Migrations', function () {
+    describe('add-primary-key-to-lock-table', function () {
+        it('skips sqlite primary key creation when the constraint exists', function () {
+            const table = sinon.stub();
+            const connection = {
+                client: {
+                    config: {
+                        client: 'sqlite3'
+                    }
+                },
+                raw: sinon.stub().resolves([{origin: 'pk'}]),
+                schema: {
+                    table: table
+                }
+            };
+
+            return addPrimaryKeyToLockTable.up(connection).then(function () {
+                table.called.should.eql(false);
+            });
+        });
+
+        it('skips duplicate mysql primary key errors', function () {
+            const duplicatePrimaryKeyError = new Error('multiple primary keys');
+            duplicatePrimaryKeyError.code = 'ER_MULTIPLE_PRI_KEY';
+
+            const connection = {
+                client: {
+                    config: {
+                        client: 'mysql2'
+                    }
+                },
+                schema: {
+                    table: sinon.stub().rejects(duplicatePrimaryKeyError)
+                }
+            };
+
+            return addPrimaryKeyToLockTable.up(connection);
+        });
+
+        it('rejects unexpected mysql primary key errors', function () {
+            const connection = {
+                client: {
+                    config: {
+                        client: 'mysql2'
+                    }
+                },
+                schema: {
+                    table: sinon.stub().rejects(new Error('table missing'))
+                }
+            };
+
+            return addPrimaryKeyToLockTable.up(connection).then(function () {
+                true.should.eql(false);
+            }).catch(function (err) {
+                err.message.should.eql('table missing');
+            });
+        });
+    });
+
+    describe('lock-table', function () {
+        it('creates the migration lock table', function () {
+            const primary = sinon.stub();
+            const nullable = sinon.stub().returns({primary: primary});
+            const defaultValue = sinon.stub();
+            const string = sinon.stub().returns({nullable: nullable});
+            const boolean = sinon.stub().returns({default: defaultValue});
+            const dateTime = sinon.stub().returns({nullable: sinon.stub()});
+            const insert = sinon.stub().resolves();
+            const connection = sinon.stub().returns({insert: insert});
+
+            connection.schema = {
+                hasTable: sinon.stub().resolves(false),
+                createTable: sinon.stub().callsFake(function (tableName, callback) {
+                    tableName.should.eql('migrations_lock');
+                    callback({
+                        string: string,
+                        boolean: boolean,
+                        dateTime: dateTime
+                    });
+                    return Promise.resolve();
+                })
+            };
+
+            return lockTable.up(connection).then(function () {
+                string.calledWith('lock_key', 191).should.eql(true);
+                nullable.calledWith(false).should.eql(true);
+                primary.calledOnce.should.eql(true);
+                boolean.calledWith('locked').should.eql(true);
+                defaultValue.calledWith(0).should.eql(true);
+                dateTime.calledWith('acquired_at').should.eql(true);
+                dateTime.calledWith('released_at').should.eql(true);
+                connection.calledWith('migrations_lock').should.eql(true);
+                insert.calledWith({
+                    lock_key: 'km01',
+                    locked: 0
+                }).should.eql(true);
+            });
+        });
+
+        it('does nothing when the migration lock table already exists', function () {
+            const connection = {
+                schema: {
+                    hasTable: sinon.stub().resolves(true),
+                    createTable: sinon.stub()
+                }
+            };
+
+            return lockTable.up(connection).then(function () {
+                connection.schema.createTable.called.should.eql(false);
+            });
+        });
+    });
+});

--- a/test/unit/utils_spec.js
+++ b/test/unit/utils_spec.js
@@ -33,6 +33,21 @@ describe('Utils', function () {
                 err.message.should.eql('Please provide a file named MigratorConfig.js in your project root.');
             }
         });
+
+        it('does not hide missing dependencies from MigratorConfig.js', function () {
+            const configPath = path.join(__dirname, 'fixtures', 'broken-config');
+
+            try {
+                utils.loadConfig({
+                    knexMigratorFilePath: configPath
+                });
+                true.should.eql(false);
+            } catch (err) {
+                err.message.should.not.eql('Please provide a file named MigratorConfig.js in your project root.');
+                err.code.should.eql('MODULE_NOT_FOUND');
+                err.stack.should.match(/Cannot find module 'missing-config-dependency'/);
+            }
+        });
     });
 
     describe('getKnexMigrator', function () {

--- a/test/unit/utils_spec.js
+++ b/test/unit/utils_spec.js
@@ -5,6 +5,36 @@ const sinon = require('sinon');
 const path = require('path');
 
 describe('Utils', function () {
+    afterEach(function () {
+        sinon.restore();
+    });
+
+    describe('loadConfig', function () {
+        it('uses a provided config object directly', function () {
+            const config = {
+                database: {},
+                migrationPath: 'migrations',
+                currentVersion: '1.0'
+            };
+
+            utils.loadConfig({
+                knexMigratorConfig: config
+            }).should.eql(config);
+        });
+
+        it('throws a helpful error when MigratorConfig.js is missing', function () {
+            try {
+                utils.loadConfig({
+                    knexMigratorFilePath: path.join(__dirname, 'missing-config')
+                });
+                true.should.eql(false);
+            } catch (err) {
+                should.not.exist(err.code);
+                err.message.should.eql('Please provide a file named MigratorConfig.js in your project root.');
+            }
+        });
+    });
+
     describe('getKnexMigrator', function () {
         it('resolves with path to installation of knex-migrator', function (done) {
             utils.getKnexMigrator({path: process.cwd()})
@@ -122,10 +152,6 @@ describe('Utils', function () {
     });
 
     describe('readFolders', function () {
-        beforeEach(function () {
-            sinon.restore();
-        });
-
         it('ensure order', function () {
             sinon.stub(fs, 'readdirSync').returns(['1.0', '2.0', '2.3', '2.13']);
             let folders = utils.readVersionFolders(path.join(__dirname, 'assets', 'migrations', 'versions'));
@@ -168,6 +194,37 @@ describe('Utils', function () {
                 '1.21',
                 '1.22'
             ]);
+        });
+
+        it('ignores dot folders', function () {
+            sinon.stub(fs, 'readdirSync').returns(['.DS_Store', '1.0']);
+            let folders = utils.readVersionFolders(path.join(__dirname, 'assets', 'migrations', 'versions'));
+            folders.should.eql(['1.0']);
+        });
+
+        it('returns an empty folder list directly', function () {
+            sinon.stub(fs, 'readdirSync').returns([]);
+            let folders = utils.readVersionFolders(path.join(__dirname, 'assets', 'migrations', 'versions'));
+            folders.should.eql([]);
+        });
+    });
+
+    describe('listFiles', function () {
+        it('ignores dot files', function () {
+            sinon.stub(fs, 'readdirSync').returns(['.hidden', '1-test.js']);
+            utils.listFiles('migrations').should.eql(['1-test.js']);
+        });
+
+        it('throws a migration path error when the directory is missing', function () {
+            sinon.stub(fs, 'readdirSync').throws(new Error('missing'));
+
+            try {
+                utils.listFiles('missing');
+                true.should.eql(false);
+            } catch (err) {
+                err.code.should.eql('MIGRATION_PATH');
+                err.message.should.eql('MigrationPath is wrong: missing');
+            }
         });
     });
 });


### PR DESCRIPTION
ref [GVA-821](https://linear.app/ghost/issue/GVA-821/clean-repos-knex-migrator)

## Summary
- Fix the `coverage` script so it runs the full test suite and enforces 80% thresholds for lines, functions, and branches.
- Add focused unit coverage for database setup/drop paths, migration table changes, locking, rollback filters, migrator helper error paths, and project-local Knex resolution.
- Prefer the consuming project's local `knex` module when creating migration connections, restoring Ghost compatibility after the package's Knex 3 dependency update.
- Add `yarn smoke:ghost`, which runs against Ghost's real `MigratorConfig.js`: `migrate --init`, `health`, rollback from `6.50` to `6.48`, forced migrate back to `6.50`, and `health` against an isolated SQLite DB.
- Update CI to run lint plus coverage, add the Ghost consumer-smoke job, and expose a stable `All tests pass` aggregate job that requires both the package matrix and consumer smoke.

## Ghost consumer smoke
- Locally, `GHOST_CORE_PATH` can point either at a Ghost repository checkout or directly at `ghost/core`.
- In CI, the smoke checks out the full Ghost repository (`fetch-depth: 0`), installs Ghost dependencies, links this PR checkout into `Ghost/ghost/core` with `pnpm link`, and executes `Ghost/ghost/core/node_modules/.bin/knex-migrator` with `KNEX_MIGRATOR_CWD` set to Ghost core.
- Ghost enforces pnpm through its `packageManager` field, so the consumer-side link uses pnpm rather than Yarn. The linked package is still the current PR checkout.
- That means the CI smoke verifies the current PR branch package through Ghost's linked installed command path, not just this repository's source bin.

## Coverage
- Baseline manual coverage before this change: lines 80.17%, functions 85.02%, branches 67.06%.
- Final `yarn coverage`: statements 89.97%, lines 89.84%, functions 94.04%, branches 81.34%.

## Consumer finding
- The first Ghost smoke attempt exposed a real current-package regression: this checkout failed Ghost `migrate --init` during fixture insertion because `knex-migrator` created transactions with its bundled Knex 3 while Ghost's migration code was using Ghost's local Knex 2.4.2 query builders.
- Ghost's installed `knex-migrator@5.3.2` passed the same `migrate --init` check, confirming this was introduced by the package-side Knex 3 move rather than by Ghost's migration scripts.
- The fix keeps standalone behavior intact but uses the project-local Knex when a project path is available.
- Daisy.js does not consume `knex-migrator`; it uses plain `knex migrate:latest` / `knex migrate:rollback` from `knexfile.js`, so this package PR does not add a Daisy consumer smoke.

## Verification
- `yarn lint`
- `yarn coverage`
- `GHOST_CORE_PATH=/Users/aileen/code/tryghost/Ghost yarn smoke:ghost`
- `yarn test`
- `NODE_ENV=testing-better-sqlite3 yarn coverage`
- `npm pack --dry-run --json`

## Notes
- Local MySQL coverage initially could not be completed in this workspace because the local root credentials were rejected. GitHub CI subsequently passed every MySQL service-container matrix leg.
- The required-check ruleset/settings step should be applied after this PR lands and the new `All tests pass` job exists on `main`.
