### PR TITLE
Replace ESLint with oxlint and oxfmt

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,9 +1,0 @@
-module.exports = {
-    plugins: ['ghost'],
-    extends: [
-        'plugin:ghost/node'
-    ],
-    parserOptions: {
-        ecmaVersion: 2018
-    }
-};

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,21 @@ on:
 permissions:
   contents: read
 jobs:
+  lint:
+    name: Lint and format
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: '22.13.1'
+      - name: Install Corepack
+        run: npm install --global corepack@0.34.6
+      - name: Enable corepack
+        run: corepack enable
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm lint
+
   test:
     runs-on: ubuntu-latest
     services:
@@ -55,7 +70,6 @@ jobs:
           echo "database__connection__port=${{ job.services.mysql.ports['3306'] }}" >> $GITHUB_ENV
 
       - run: pnpm install --frozen-lockfile
-      - run: pnpm lint
       - run: pnpm coverage
 
   ghost-consumer-smoke:
@@ -100,12 +114,16 @@ jobs:
     name: All tests pass
     runs-on: ubuntu-latest
     needs:
+      - lint
       - test
       - ghost-consumer-smoke
     if: always()
     steps:
       - name: Check required jobs
         run: |
+          if [[ "${{ needs.lint.result }}" != "success" ]]; then
+            exit 1
+          fi
           if [[ "${{ needs.test.result }}" != "success" ]]; then
             exit 1
           fi

--- a/.gitignore
+++ b/.gitignore
@@ -46,5 +46,3 @@ config.*.json
 
 # OSX
 .DS_Store
-
-.eslintcache

--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -1,0 +1,16 @@
+{
+    "$schema": "./node_modules/oxfmt/configuration_schema.json",
+    "singleQuote": true,
+    "tabWidth": 4,
+    "sortPackageJson": false,
+    "ignorePatterns": [
+        "**/node_modules/**",
+        "**/coverage/**",
+        "pnpm-lock.yaml",
+        "**/*.json",
+        "**/*.jsonc",
+        "**/*.yml",
+        "**/*.yaml",
+        "**/*.md"
+    ]
+}

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -1,0 +1,33 @@
+{
+    "$schema": "./node_modules/oxlint/configuration_schema.json",
+    "categories": {
+        "correctness": "error",
+        "suspicious": "warn"
+    },
+    "env": {
+        "node": true,
+        "es2024": true
+    },
+    "overrides": [
+        {
+            "files": ["test/**/*.js"],
+            "env": {
+                "mocha": true
+            },
+            "rules": {
+                "no-unused-expressions": "off",
+                "no-unused-vars": "off",
+                "unicorn/no-thenable": "off"
+            }
+        },
+        {
+            "files": ["scripts/**/*.js"],
+            "rules": {
+                "no-console": "off"
+            }
+        }
+    ],
+    "rules": {
+        "no-console": "error"
+    }
+}

--- a/README.md
+++ b/README.md
@@ -326,8 +326,8 @@ knexMigrator.isDatabaseOK()
 
 # Test
 
-- `pnpm lint` run just eslint
-- `pnpm test` run eslint && then tests
+- `pnpm lint` runs oxlint and checks formatting
+- `pnpm test` runs tests and then lint
 - `NODE_ENV=testing-mysql pnpm test` to test with MySQL
 
 # Publish
@@ -337,7 +337,6 @@ knexMigrator.isDatabaseOK()
 # Copyright & License
 
 Copyright (c) 2013-2026 Ghost Foundation - Released under the [MIT license](LICENSE).
-
 
 
 

--- a/lib/database.js
+++ b/lib/database.js
@@ -4,7 +4,7 @@ const path = require('path'),
     debug = require('debug')('knex-migrator:database'),
     errors = require('./errors');
 const DatabaseInfo = require('@tryghost/database-info');
-const {sequence} = require('@tryghost/promise');
+const { sequence } = require('@tryghost/promise');
 
 function loadKnex(options) {
     options = options || {};
@@ -14,14 +14,16 @@ function loadKnex(options) {
 
         try {
             resolvedKnexPath = require.resolve('knex', {
-                paths: [path.resolve(options.knexModulePath)]
+                paths: [path.resolve(options.knexModulePath)],
             });
         } catch (err) {
             if (err.code !== 'MODULE_NOT_FOUND') {
                 throw err;
             }
 
-            debug('Could not load project knex from ' + options.knexModulePath + ': ' + err.message);
+            debug(
+                'Could not load project knex from ' + options.knexModulePath + ': ' + err.message,
+            );
         }
 
         if (resolvedKnexPath) {
@@ -71,22 +73,21 @@ exports.connect = function connect(options, connectionOptions) {
  * @returns {Promise<R> | Promise<any> | Promise<T>}
  */
 exports.ensureConnectionWorks = (connection) => {
-    return connection.raw('SELECT 1+1 as RESULT;')
-        .catch((err) => {
-            if (err.code === 'ENOTFOUND' || err.code === 'ETIMEDOUT' || err.code === 'EAI_AGAIN') {
-                throw new errors.DatabaseError({
-                    message: 'Invalid database host.',
-                    help: 'Please double check your database config.',
-                    err: err
-                });
-            }
-
+    return connection.raw('SELECT 1+1 as RESULT;').catch((err) => {
+        if (err.code === 'ENOTFOUND' || err.code === 'ETIMEDOUT' || err.code === 'EAI_AGAIN') {
             throw new errors.DatabaseError({
-                message: err.message,
-                help: 'Unknown database error',
-                err: err
+                message: 'Invalid database host.',
+                help: 'Please double check your database config.',
+                err: err,
             });
+        }
+
+        throw new errors.DatabaseError({
+            message: err.message,
+            help: 'Unknown database error',
+            err: err,
         });
+    });
 };
 
 /**
@@ -136,19 +137,25 @@ exports.createDatabaseIfNotExist = function createDatabaseIfNotExist(dbConfig, c
     if (DatabaseInfo.isSQLiteConfig(dbConfig)) {
         return Promise.resolve();
     } else if (!DatabaseInfo.isMySQLConfig(dbConfig)) {
-        return Promise.reject(new errors.KnexMigrateError({
-            message: 'Database is not supported.'
-        }));
+        return Promise.reject(
+            new errors.KnexMigrateError({
+                message: 'Database is not supported.',
+            }),
+        );
     }
 
-    const connection = exports.connect({
-        client: dbConfig.client,
-        connection: omit(dbConfig.connection, ['database'])
-    }, connectionOptions);
+    const connection = exports.connect(
+        {
+            client: dbConfig.client,
+            connection: omit(dbConfig.connection, ['database']),
+        },
+        connectionOptions,
+    );
 
     debug('Create database', name);
 
-    return exports.ensureConnectionWorks(connection)
+    return exports
+        .ensureConnectionWorks(connection)
         .then(function () {
             return connection.raw('CREATE DATABASE `' + name + '` CHARACTER SET ' + charset + ';');
         })
@@ -161,7 +168,7 @@ exports.createDatabaseIfNotExist = function createDatabaseIfNotExist(dbConfig, c
             throw new errors.DatabaseError({
                 message: err.message,
                 err: err,
-                code: 'DATABASE_CREATION_FAILED'
+                code: 'DATABASE_CREATION_FAILED',
             });
         })
         .finally(function () {
@@ -193,16 +200,19 @@ exports.drop = function drop(options) {
     if (DatabaseInfo.isMySQL(connection)) {
         debug('Drop database: ' + dbConfig.connection.database);
 
-        return connection.raw('DROP DATABASE `' + dbConfig.connection.database + '`;')
+        return connection
+            .raw('DROP DATABASE `' + dbConfig.connection.database + '`;')
             .catch(function (err) {
                 // CASE: database does not exist, skip
                 if (err.errno === 1049) {
                     return Promise.resolve();
                 }
 
-                return Promise.reject(new errors.KnexMigrateError({
-                    err: err
-                }));
+                return Promise.reject(
+                    new errors.KnexMigrateError({
+                        err: err,
+                    }),
+                );
             });
     } else if (DatabaseInfo.isSQLite(connection)) {
         // @NOTE: sqlite3 does not support "DROP DATABASE". We have to drop each table instead.
@@ -218,15 +228,17 @@ exports.drop = function drop(options) {
                 return connection.raw(`SELECT name FROM sqlite_master WHERE type='table';`);
             })
             .then(function (tables) {
-                return sequence(tables.map(table => () => {
-                    if (table.name === 'sqlite_sequence') {
-                        debug('Skip drop table: ' + table.name);
-                        return Promise.resolve();
-                    }
+                return sequence(
+                    tables.map((table) => () => {
+                        if (table.name === 'sqlite_sequence') {
+                            debug('Skip drop table: ' + table.name);
+                            return Promise.resolve();
+                        }
 
-                    debug('Drop table: ' + table.name);
-                    return connection.schema.dropTableIfExists(table.name);
-                }));
+                        debug('Drop table: ' + table.name);
+                        return connection.schema.dropTableIfExists(table.name);
+                    }),
+                );
             })
             .catch(function (err) {
                 // CASE: database file was never initialised
@@ -234,9 +246,11 @@ exports.drop = function drop(options) {
                     return Promise.resolve();
                 }
 
-                return Promise.reject(new errors.KnexMigrateError({
-                    err: err
-                }));
+                return Promise.reject(
+                    new errors.KnexMigrateError({
+                        err: err,
+                    }),
+                );
             })
             .finally(function () {
                 if (isBetterSqlite) {
@@ -244,8 +258,10 @@ exports.drop = function drop(options) {
                 }
             });
     } else {
-        return Promise.reject(new errors.KnexMigrateError({
-            message: 'Database client not supported: ' + dbConfig.client
-        }));
+        return Promise.reject(
+            new errors.KnexMigrateError({
+                message: 'Database client not supported: ' + dbConfig.client,
+            }),
+        );
     }
 };

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -6,77 +6,122 @@ class KnexMigrateError extends errors.MigrationError {}
 const knexMigratorErrors = {
     MigrationExistsError: class MigrationExistsError extends KnexMigrateError {
         constructor(options) {
-            super(merge({
-                id: 100,
-                errorType: 'MigrationExistsError'
-            }, options));
+            super(
+                merge(
+                    {
+                        id: 100,
+                        errorType: 'MigrationExistsError',
+                    },
+                    options,
+                ),
+            );
         }
     },
     DatabaseIsNotOkError: class DatabaseIsNotOkError extends KnexMigrateError {
         constructor(options) {
-            super(merge({
-                id: 200,
-                errorType: 'DatabaseIsNotOkError',
-                help: 'If knex-migrator is not installed, please run "npm install -g knex-migrator" \nRead more here: https://github.com/TryGhost/knex-migrator'
-            }, options));
+            super(
+                merge(
+                    {
+                        id: 200,
+                        errorType: 'DatabaseIsNotOkError',
+                        help: 'If knex-migrator is not installed, please run "npm install -g knex-migrator" \nRead more here: https://github.com/TryGhost/knex-migrator',
+                    },
+                    options,
+                ),
+            );
         }
     },
     MigrationScriptError: class MigrationScriptError extends KnexMigrateError {
         constructor(options) {
-            super(merge({
-                id: 300,
-                errorType: 'MigrationScriptError'
-            }, options));
+            super(
+                merge(
+                    {
+                        id: 300,
+                        errorType: 'MigrationScriptError',
+                    },
+                    options,
+                ),
+            );
         }
     },
     RollbackError: class RollbackError extends KnexMigrateError {
         constructor(options) {
-            super(merge({
-                id: 400,
-                errorType: 'RollbackError'
-            }, options));
+            super(
+                merge(
+                    {
+                        id: 400,
+                        errorType: 'RollbackError',
+                    },
+                    options,
+                ),
+            );
         }
     },
     MigrationsAreLockedError: class MigrationsAreLockedError extends KnexMigrateError {
         constructor(options) {
-            super(merge({
-                id: 500,
-                errorType: 'MigrationsAreLockedError'
-            }, options));
+            super(
+                merge(
+                    {
+                        id: 500,
+                        errorType: 'MigrationsAreLockedError',
+                    },
+                    options,
+                ),
+            );
         }
     },
     LockError: class LockError extends KnexMigrateError {
         constructor(options) {
-            super(merge({
-                id: 500,
-                errorType: 'LockError'
-            }, options));
+            super(
+                merge(
+                    {
+                        id: 500,
+                        errorType: 'LockError',
+                    },
+                    options,
+                ),
+            );
         }
     },
     UnlockError: class UnlockError extends KnexMigrateError {
         constructor(options) {
-            super(merge({
-                id: 500,
-                errorType: 'UnlockError'
-            }, options));
+            super(
+                merge(
+                    {
+                        id: 500,
+                        errorType: 'UnlockError',
+                    },
+                    options,
+                ),
+            );
         }
     },
     DatabaseError: class DatabaseError extends KnexMigrateError {
         constructor(options) {
-            super(merge({
-                id: 500,
-                errorType: 'DatabaseError'
-            }, options));
+            super(
+                merge(
+                    {
+                        id: 500,
+                        errorType: 'DatabaseError',
+                    },
+                    options,
+                ),
+            );
         }
     },
     IrreversibleMigrationError: class IrreversibleMigrationError extends KnexMigrateError {
         constructor(options) {
-            super(merge({
-                id: 500,
-                errorType: 'IrreversibleMigrationError'
-            }, options));
+            super(
+                merge(
+                    {
+                        id: 500,
+                        errorType: 'IrreversibleMigrationError',
+                    },
+                    options,
+                ),
+            );
         }
-    }
+    },
 };
 
 module.exports = Object.assign(knexMigratorErrors, errors);

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,6 @@
 const _ = require('lodash');
 const path = require('path');
-const {sequence} = require('@tryghost/promise');
+const { sequence } = require('@tryghost/promise');
 const debug = require('debug')('knex-migrator:index');
 const database = require('./database');
 const utils = require('./utils');
@@ -82,9 +82,10 @@ KnexMigrator.prototype.init = function init(options) {
         debug('No hooks found, no problem.');
     }
 
-    this.connection = database.connect(this.dbConfig, {knexModulePath: this.knexModulePath});
+    this.connection = database.connect(this.dbConfig, { knexModulePath: this.knexModulePath });
 
-    return database.createDatabaseIfNotExist(self.dbConfig, {knexModulePath: this.knexModulePath})
+    return database
+        .createDatabaseIfNotExist(self.dbConfig, { knexModulePath: this.knexModulePath })
         .then(function () {
             if (noScripts) {
                 return;
@@ -93,12 +94,13 @@ KnexMigrator.prototype.init = function init(options) {
             // @NOTE: create table outside of the transaction! (implicit)
             return database.createMigrationsTable(self.connection).then(function () {
                 return migrations.run(self.connection).then(function () {
-                    return locking.lock(self.connection)
+                    return locking
+                        .lock(self.connection)
                         .then(function () {
                             if (hooks.before) {
                                 debug('Before hook');
                                 return hooks.before({
-                                    connection: self.connection
+                                    connection: self.connection,
                                 });
                             }
                         })
@@ -106,7 +108,7 @@ KnexMigrator.prototype.init = function init(options) {
                             return self._migrateTo({
                                 version: 'init',
                                 only: options.only,
-                                skip: options.skip
+                                skip: options.skip,
                             });
                         })
                         .then(function (response) {
@@ -115,12 +117,14 @@ KnexMigrator.prototype.init = function init(options) {
                             if (hooks.after) {
                                 debug('After hook');
                                 return hooks.after({
-                                    connection: self.connection
+                                    connection: self.connection,
                                 });
                             }
                         })
                         .then(function () {
-                            const initTasks = utils.listFiles(path.join(self.migrationPath, 'init'));
+                            const initTasks = utils.listFiles(
+                                path.join(self.migrationPath, 'init'),
+                            );
 
                             /**
                              * CASE 1: You can disable init completion manually
@@ -145,8 +149,10 @@ KnexMigrator.prototype.init = function init(options) {
                             // CASE: insert all migration files, otherwise you will run into problems
                             // e.g. you are on 1.2, you initialise the database, but there is 1.3 migration script
                             try {
-                                versionsToMigrateTo = utils.readVersionFolders(
-                                    path.join(self.migrationPath, self.subfolder)) || [];
+                                versionsToMigrateTo =
+                                    utils.readVersionFolders(
+                                        path.join(self.migrationPath, self.subfolder),
+                                    ) || [];
                             } catch (err) {
                                 // CASE: versions folder does not exists
                                 if (err.code === 'READ_FOLDERS') {
@@ -156,34 +162,44 @@ KnexMigrator.prototype.init = function init(options) {
                                 throw err;
                             }
 
-                            return database.createTransaction(self.connection, async function (transacting) {
-                                const existingMigrations = await transacting('migrations').select('name');
-                                const existingMigrationsNames = existingMigrations.map(m => m.name);
-                                const migrationsToAdd = [];
+                            return database.createTransaction(
+                                self.connection,
+                                async function (transacting) {
+                                    const existingMigrations =
+                                        await transacting('migrations').select('name');
+                                    const existingMigrationsNames = existingMigrations.map(
+                                        (m) => m.name,
+                                    );
+                                    const migrationsToAdd = [];
 
-                                // CASE: Run over all migration scripts and add the file name to the database.
-                                for (const versionToMigrateTo of versionsToMigrateTo) {
-                                    let versionPath = path.join(self.migrationPath, self.subfolder, versionToMigrateTo);
-                                    let filesToMigrateTo = utils.listFiles(versionPath) || [];
+                                    // CASE: Run over all migration scripts and add the file name to the database.
+                                    for (const versionToMigrateTo of versionsToMigrateTo) {
+                                        let versionPath = path.join(
+                                            self.migrationPath,
+                                            self.subfolder,
+                                            versionToMigrateTo,
+                                        );
+                                        let filesToMigrateTo = utils.listFiles(versionPath) || [];
 
-                                    // CASE: check if migration exists, do not insert twice
-                                    for (const name of filesToMigrateTo) {
-                                        if (existingMigrationsNames.includes(name)) {
-                                            continue;
+                                        // CASE: check if migration exists, do not insert twice
+                                        for (const name of filesToMigrateTo) {
+                                            if (existingMigrationsNames.includes(name)) {
+                                                continue;
+                                            }
+
+                                            migrationsToAdd.push({
+                                                name,
+                                                version: versionToMigrateTo,
+                                                currentVersion: self.currentVersion,
+                                            });
                                         }
-
-                                        migrationsToAdd.push({
-                                            name,
-                                            version: versionToMigrateTo,
-                                            currentVersion: self.currentVersion
-                                        });
                                     }
-                                }
 
-                                await self.connection
-                                    .batchInsert('migrations', migrationsToAdd)
-                                    .transacting(transacting);
-                            });
+                                    await self.connection
+                                        .batchInsert('migrations', migrationsToAdd)
+                                        .transacting(transacting);
+                                },
+                            );
                         })
                         .then(function () {
                             return locking.unlock(self.connection);
@@ -197,10 +213,9 @@ KnexMigrator.prototype.init = function init(options) {
                                 throw err;
                             }
 
-                            return locking.unlock(self.connection)
-                                .then(function () {
-                                    throw err;
-                                });
+                            return locking.unlock(self.connection).then(function () {
+                                throw err;
+                            });
                         });
                 });
             });
@@ -226,24 +241,27 @@ KnexMigrator.prototype.init = function init(options) {
 
             debug('Rolling back: ' + err.message);
 
-            return self._rollback({
-                version: 'init',
-                skippedTasks: {
-                    init: skippedTasks
-                }
-            }).then(function () {
-                throw err;
-            }).catch(function (innerErr) {
-                if (errors.utils.isGhostError(innerErr)) {
+            return self
+                ._rollback({
+                    version: 'init',
+                    skippedTasks: {
+                        init: skippedTasks,
+                    },
+                })
+                .then(function () {
                     throw err;
-                }
+                })
+                .catch(function (innerErr) {
+                    if (errors.utils.isGhostError(innerErr)) {
+                        throw err;
+                    }
 
-                throw new errors.RollbackError({
-                    message: innerErr.message,
-                    err: innerErr,
-                    context: `OuterError: ${err.message}`
+                    throw new errors.RollbackError({
+                        message: innerErr.message,
+                        err: innerErr,
+                        context: `OuterError: ${err.message}`,
+                    });
                 });
-            });
         })
         .finally(function () {
             let ops = [];
@@ -252,22 +270,23 @@ KnexMigrator.prototype.init = function init(options) {
                 ops.push(function shutdownHook() {
                     debug('Shutdown hook');
                     return hooks.shutdown({
-                        executedFromShell: self.executedFromShell
+                        executedFromShell: self.executedFromShell,
                     });
                 });
             }
 
             ops.push(function destroyConnection() {
                 debug('Destroy connection');
-                return self.connection.destroy()
-                    .then(function () {
-                        debug('Destroyed connection');
-                    });
+                return self.connection.destroy().then(function () {
+                    debug('Destroyed connection');
+                });
             });
 
-            return sequence(ops.map(op => () => {
-                return op.bind(self)();
-            }));
+            return sequence(
+                ops.map((op) => () => {
+                    return op.bind(self)();
+                }),
+            );
         });
 };
 
@@ -321,7 +340,7 @@ KnexMigrator.prototype.migrate = async function migrate(options) {
         debug('No hooks found, no problem.');
     }
 
-    this.connection = database.connect(this.dbConfig, {knexModulePath: this.knexModulePath});
+    this.connection = database.connect(this.dbConfig, { knexModulePath: this.knexModulePath });
 
     try {
         await database.ensureConnectionWorks(this.connection);
@@ -330,7 +349,7 @@ KnexMigrator.prototype.migrate = async function migrate(options) {
 
         await locking.lock(this.connection);
 
-        const result = await this._integrityCheck({force});
+        const result = await this._integrityCheck({ force });
 
         _.each(result, function (_value, version) {
             // CASE: Log which versions won't be executed based on the "only" flag
@@ -363,7 +382,7 @@ KnexMigrator.prototype.migrate = async function migrate(options) {
             if (hooks.before) {
                 debug('Before hook');
                 await hooks.before({
-                    connection: this.connection
+                    connection: this.connection,
                 });
             }
 
@@ -374,7 +393,7 @@ KnexMigrator.prototype.migrate = async function migrate(options) {
                     await this._migrateTo({
                         version: versionToMigrate,
                         only: onlyFile,
-                        hooks: hooks
+                        hooks: hooks,
                     });
                 } catch (err) {
                     // CASE: Do not rollback if migrations are locked
@@ -400,14 +419,14 @@ KnexMigrator.prototype.migrate = async function migrate(options) {
 
                     const versionsMigrated = versionsToMigrate.slice(
                         0,
-                        versionsToMigrate.indexOf(versionToMigrate) + 1
+                        versionsToMigrate.indexOf(versionToMigrate) + 1,
                     );
 
                     versionsMigrated.reverse();
 
                     try {
                         for (const versionMigrated of versionsMigrated) {
-                            await this._rollback({version: versionMigrated, task: err.context});
+                            await this._rollback({ version: versionMigrated, task: err.context });
                         }
                         logging.info(`Rollback was successful.`);
                         throw err;
@@ -419,7 +438,7 @@ KnexMigrator.prototype.migrate = async function migrate(options) {
                         throw new errors.RollbackError({
                             message: innerErr.message,
                             err: innerErr,
-                            context: `OuterError: ${err.message}`
+                            context: `OuterError: ${err.message}`,
                         });
                     } finally {
                         await locking.unlock(this.connection);
@@ -430,7 +449,7 @@ KnexMigrator.prototype.migrate = async function migrate(options) {
             if (hooks.after) {
                 debug('After hook');
                 await hooks.after({
-                    connection: this.connection
+                    connection: this.connection,
                 });
             }
         }
@@ -439,7 +458,7 @@ KnexMigrator.prototype.migrate = async function migrate(options) {
         if (hooks.shutdown) {
             debug('Shutdown hook');
             await hooks.shutdown({
-                executedFromShell: this.executedFromShell
+                executedFromShell: this.executedFromShell,
             });
         }
 
@@ -473,30 +492,33 @@ KnexMigrator.prototype.reset = function reset(options) {
     let self = this;
     let force = options.force;
 
-    this.connection = database.connect(this.dbConfig, {knexModulePath: this.knexModulePath});
+    this.connection = database.connect(this.dbConfig, { knexModulePath: this.knexModulePath });
 
     // CASE: ignore lock completely and drop the db
     if (force) {
-        return database.drop({
-            connection: self.connection,
-            dbConfig: self.dbConfig
-        }).catch(function onRestError(err) {
-            // Database does not exist. MySql.
-            if (err.errno === 1049) {
-                return Promise.resolve();
-            }
+        return database
+            .drop({
+                connection: self.connection,
+                dbConfig: self.dbConfig,
+            })
+            .catch(function onRestError(err) {
+                // Database does not exist. MySql.
+                if (err.errno === 1049) {
+                    return Promise.resolve();
+                }
 
-            throw err;
-        }).finally(function () {
-            debug('Destroy connection');
-            return self.connection.destroy()
-                .then(function () {
+                throw err;
+            })
+            .finally(function () {
+                debug('Destroy connection');
+                return self.connection.destroy().then(function () {
                     debug('Destroyed connection');
                 });
-        });
+            });
     }
 
-    return database.ensureConnectionWorks(this.connection)
+    return database
+        .ensureConnectionWorks(this.connection)
         .then(function () {
             return migrations.run(self.connection);
         })
@@ -506,7 +528,7 @@ KnexMigrator.prototype.reset = function reset(options) {
         .then(function () {
             return database.drop({
                 connection: self.connection,
-                dbConfig: self.dbConfig
+                dbConfig: self.dbConfig,
             });
         })
         .catch(function onRestError(err) {
@@ -526,17 +548,15 @@ KnexMigrator.prototype.reset = function reset(options) {
                 return Promise.resolve();
             }
 
-            return locking.unlock(self.connection)
-                .then(function () {
-                    throw err;
-                });
+            return locking.unlock(self.connection).then(function () {
+                throw err;
+            });
         })
         .finally(function () {
             debug('Destroy connection');
-            return self.connection.destroy()
-                .then(function () {
-                    debug('Destroyed connection');
-                });
+            return self.connection.destroy().then(function () {
+                debug('Destroyed connection');
+            });
         });
 };
 
@@ -564,9 +584,10 @@ KnexMigrator.prototype.reset = function reset(options) {
  */
 KnexMigrator.prototype.isDatabaseOK = function isDatabaseOK() {
     let self = this;
-    this.connection = database.connect(this.dbConfig, {knexModulePath: this.knexModulePath});
+    this.connection = database.connect(this.dbConfig, { knexModulePath: this.knexModulePath });
 
-    return database.ensureConnectionWorks(this.connection)
+    return database
+        .ensureConnectionWorks(this.connection)
         .then(function () {
             return migrations.run(self.connection);
         })
@@ -581,7 +602,7 @@ KnexMigrator.prototype.isDatabaseOK = function isDatabaseOK() {
             if (result.init && result.init.expected > result.init.actual) {
                 throw new errors.DatabaseIsNotOkError({
                     message: 'Please run `pnpm knex-migrator init`',
-                    code: 'DB_NOT_INITIALISED'
+                    code: 'DB_NOT_INITIALISED',
                 });
             }
 
@@ -591,14 +612,15 @@ KnexMigrator.prototype.isDatabaseOK = function isDatabaseOK() {
                     throw new errors.DatabaseIsNotOkError({
                         message: 'Migrations are missing. Please run `pnpm knex-migrator migrate`.',
                         code: 'DB_NEEDS_MIGRATION',
-                        help: `Expected: ${value.expected} items in migrations table, found: ${value.actual}`
+                        help: `Expected: ${value.expected} items in migrations table, found: ${value.actual}`,
                     });
                     // CASE: there are more actual migrations than expected, something has gone wrong :(
                 } else if (value.expected < value.actual) {
                     throw new errors.DatabaseIsNotOkError({
-                        message: 'Detected more items in the migrations table than expected. Please manually inspect the migrations table.',
+                        message:
+                            'Detected more items in the migrations table than expected. Please manually inspect the migrations table.',
                         code: 'MIGRATION_STATE_ERROR',
-                        help: `Expected: ${value.expected} items in migrations table, found: ${value.actual}`
+                        help: `Expected: ${value.expected} items in migrations table, found: ${value.actual}`,
                     });
                 }
             });
@@ -608,7 +630,7 @@ KnexMigrator.prototype.isDatabaseOK = function isDatabaseOK() {
             if (err.errno === 1049) {
                 throw new errors.DatabaseIsNotOkError({
                     message: 'Please run `pnpm knex-migrator init`',
-                    code: 'DB_NOT_INITIALISED'
+                    code: 'DB_NOT_INITIALISED',
                 });
             }
 
@@ -620,10 +642,9 @@ KnexMigrator.prototype.isDatabaseOK = function isDatabaseOK() {
             }
 
             debug('Destroy connection');
-            return self.connection.destroy()
-                .then(function () {
-                    debug('Destroyed connection');
-                });
+            return self.connection.destroy().then(function () {
+                debug('Destroyed connection');
+            });
         });
 };
 
@@ -654,7 +675,7 @@ KnexMigrator.prototype.rollback = function rollback(options) {
     let disableHooks = options.disableHooks;
     let hooks = {};
 
-    this.connection = database.connect(this.dbConfig, {knexModulePath: this.knexModulePath});
+    this.connection = database.connect(this.dbConfig, { knexModulePath: this.knexModulePath });
 
     const helper = function helper() {
         return new Promise(function (resolve, reject) {
@@ -669,70 +690,79 @@ KnexMigrator.prototype.rollback = function rollback(options) {
             }
 
             if (hooks.before) {
-                return hooks.before({
-                    connection: self.connection
-                }).then(resolve).catch(reject);
+                return hooks
+                    .before({
+                        connection: self.connection,
+                    })
+                    .then(resolve)
+                    .catch(reject);
             }
 
             resolve();
-        }).then(function () {
-            let whereQuery = {};
+        })
+            .then(function () {
+                let whereQuery = {};
 
-            // CASE 1: rollback to specific version (query all and filter out)
-            // CASE 2: rollback current version you are on
-            if (version) {
-                debug(`Rollback to specific version: ${version}`);
-                whereQuery = {};
-            } else {
-                whereQuery = {
-                    currentVersion: self.currentVersion
-                };
-            }
+                // CASE 1: rollback to specific version (query all and filter out)
+                // CASE 2: rollback current version you are on
+                if (version) {
+                    debug(`Rollback to specific version: ${version}`);
+                    whereQuery = {};
+                } else {
+                    whereQuery = {
+                        currentVersion: self.currentVersion,
+                    };
+                }
 
-            return self.connection('migrations')
-                .where(whereQuery)
-                .then(function (values) {
-                    if (!values.length) {
-                        throw new errors.IncorrectUsageError({
-                            message: 'No migrations available to rollback.'
-                        });
-                    }
-
-                    // CASE: filter out all versions which are smaller than the version we want to rollback to
-                    if (version) {
-                        values = _.filter(values, function (value) {
-                            return utils.isGreaterThanVersion({
-                                greaterVersion: value.version,
-                                smallerVersion: version
+                return self
+                    .connection('migrations')
+                    .where(whereQuery)
+                    .then(function (values) {
+                        if (!values.length) {
+                            throw new errors.IncorrectUsageError({
+                                message: 'No migrations available to rollback.',
                             });
-                        });
-                    }
+                        }
 
-                    // @NOTE: we never ever rollback init scripts for now.
-                    //       this can be very dangerous, because it removes tables
-                    // @EXCEPTION: you run init scripts and they fail
-                    values = _.filter(values, function (value) {
-                        return value.version !== 'init';
+                        // CASE: filter out all versions which are smaller than the version we want to rollback to
+                        if (version) {
+                            values = _.filter(values, function (value) {
+                                return utils.isGreaterThanVersion({
+                                    greaterVersion: value.version,
+                                    smallerVersion: version,
+                                });
+                            });
+                        }
+
+                        // @NOTE: we never ever rollback init scripts for now.
+                        //       this can be very dangerous, because it removes tables
+                        // @EXCEPTION: you run init scripts and they fail
+                        values = _.filter(values, function (value) {
+                            return value.version !== 'init';
+                        });
+
+                        values.reverse();
+                        return sequence(
+                            values.map((value) => () => {
+                                return self._rollback({
+                                    version: value.version,
+                                    onlyTasks: [value.name],
+                                });
+                            }),
+                        );
                     });
-
-                    values.reverse();
-                    return sequence(values.map(value => () => {
-                        return self._rollback({
-                            version: value.version,
-                            onlyTasks: [value.name]
-                        });
-                    }));
-                });
-        }).then(function () {
-            if (hooks.shutdown) {
-                return hooks.shutdown({
-                    executedFromShell: self.executedFromShell
-                });
-            }
-        });
+            })
+            .then(function () {
+                if (hooks.shutdown) {
+                    return hooks.shutdown({
+                        executedFromShell: self.executedFromShell,
+                    });
+                }
+            });
     };
 
-    return database.ensureConnectionWorks(this.connection)
+    return database
+        .ensureConnectionWorks(this.connection)
         .then(function () {
             return migrations.run(self.connection);
         })
@@ -747,15 +777,14 @@ KnexMigrator.prototype.rollback = function rollback(options) {
 
             throw new errors.IncorrectUsageError({
                 message: 'Rollback did not happen.',
-                help: 'Use --force if you want to force a rollback. By default, rollbacks are only allowed if your database is locked.'
+                help: 'Use --force if you want to force a rollback. By default, rollbacks are only allowed if your database is locked.',
             });
         })
         .catch(function (err) {
             if (err instanceof errors.MigrationsAreLockedError) {
-                return helper()
-                    .then(function () {
-                        return locking.unlock(self.connection);
-                    });
+                return helper().then(function () {
+                    return locking.unlock(self.connection);
+                });
             }
 
             throw err;
@@ -766,10 +795,9 @@ KnexMigrator.prototype.rollback = function rollback(options) {
             }
 
             debug('Destroy connection');
-            return self.connection.destroy()
-                .then(function () {
-                    debug('Destroyed connection');
-                });
+            return self.connection.destroy().then(function () {
+                debug('Destroyed connection');
+            });
         });
 };
 
@@ -850,63 +878,74 @@ KnexMigrator.prototype._rollback = function _rollback(options) {
         return !!_.get(task, 'config.irreversible');
     });
     if (irreversibleMigrations.length) {
-        return Promise.reject(new errors.IrreversibleMigrationError({
-            message: 'Unable to rollback',
-            help: 'There are irreversible migrations when rolling back to the selected version, this typically means data required for earlier versions has been deleted. Please restore from a backup instead.',
-            code: 'IRREVERSIBLE_MIGRATION'
-        }));
+        return Promise.reject(
+            new errors.IrreversibleMigrationError({
+                message: 'Unable to rollback',
+                help: 'There are irreversible migrations when rolling back to the selected version, this typically means data required for earlier versions has been deleted. Please restore from a backup instead.',
+                code: 'IRREVERSIBLE_MIGRATION',
+            }),
+        );
     }
 
     tasks.reverse();
 
-    return sequence(tasks.map(task => () => {
-        if (skippedTasks[version] && skippedTasks[version].indexOf(task.name) !== -1) {
-            return Promise.resolve();
-        }
+    return sequence(
+        tasks.map((task) => () => {
+            if (skippedTasks[version] && skippedTasks[version].indexOf(task.name) !== -1) {
+                return Promise.resolve();
+            }
 
-        if (onlyTasks.length && onlyTasks.indexOf(task.name) === -1) {
-            return Promise.resolve();
-        }
+            if (onlyTasks.length && onlyTasks.indexOf(task.name) === -1) {
+                return Promise.resolve();
+            }
 
-        if (!task.down) {
-            debug('No down function provided', task.name);
-            return self.connection('migrations')
-                .where({
-                    name: task.name,
-                    version: version,
-                    currentVersion: self.currentVersion
-                })
-                .delete();
-        }
-
-        debug('Rollback', task.name);
-
-        if (task.config && task.config.transaction) {
-            return database.createTransaction(self.connection, function (txn) {
-                return task.down({
-                    transacting: txn
-                });
-            }).then(function () {
-                return self.connection('migrations')
+            if (!task.down) {
+                debug('No down function provided', task.name);
+                return self
+                    .connection('migrations')
                     .where({
                         name: task.name,
-                        version: version
+                        version: version,
+                        currentVersion: self.currentVersion,
                     })
                     .delete();
-            });
-        }
+            }
 
-        return task.down({
-            connection: self.connection
-        }).then(function () {
-            return self.connection('migrations')
-                .where({
-                    name: task.name,
-                    version: version
+            debug('Rollback', task.name);
+
+            if (task.config && task.config.transaction) {
+                return database
+                    .createTransaction(self.connection, function (txn) {
+                        return task.down({
+                            transacting: txn,
+                        });
+                    })
+                    .then(function () {
+                        return self
+                            .connection('migrations')
+                            .where({
+                                name: task.name,
+                                version: version,
+                            })
+                            .delete();
+                    });
+            }
+
+            return task
+                .down({
+                    connection: self.connection,
                 })
-                .delete();
-        });
-    }));
+                .then(function () {
+                    return self
+                        .connection('migrations')
+                        .where({
+                            name: task.name,
+                            version: version,
+                        })
+                        .delete();
+                });
+        }),
+    );
 };
 
 /**
@@ -965,81 +1004,93 @@ KnexMigrator.prototype._migrateTo = function _migrateTo(options) {
     debug('Migrate: ' + version + ' with ' + tasks.length + ' tasks.');
     debug('Tasks: ' + JSON.stringify(tasks));
 
-    return sequence(tasks.map(task => () => {
-        return self._beforeEach({
-            task: task.name,
-            version: version
-        }).then(function () {
-            if (hooks.beforeEach) {
-                return hooks.beforeEach({
-                    connection: self.connection
-                });
-            }
-        }).then(function () {
-            debug('Running up: ' + task.name);
+    return sequence(
+        tasks.map((task) => () => {
+            return self
+                ._beforeEach({
+                    task: task.name,
+                    version: version,
+                })
+                .then(function () {
+                    if (hooks.beforeEach) {
+                        return hooks.beforeEach({
+                            connection: self.connection,
+                        });
+                    }
+                })
+                .then(function () {
+                    debug('Running up: ' + task.name);
 
-            if (task.config && task.config.transaction) {
-                return database.createTransaction(self.connection, function (txn) {
+                    if (task.config && task.config.transaction) {
+                        return database.createTransaction(self.connection, function (txn) {
+                            return task.up({
+                                transacting: txn,
+                            });
+                        });
+                    }
+
                     return task.up({
-                        transacting: txn
+                        connection: self.connection,
+                    });
+                })
+                .then(function () {
+                    if (hooks.afterEach) {
+                        return hooks.afterEach({
+                            connection: self.connection,
+                        });
+                    }
+                })
+                .then(function () {
+                    return self._afterEach({
+                        task: task,
+                        version: version,
+                    });
+                })
+                .catch(function (err) {
+                    if (err instanceof errors.MigrationExistsError) {
+                        debug('Skipping:' + task.name);
+                        skippedTasks.push(task.name);
+                        return Promise.resolve();
+                    }
+
+                    /**
+                     * @NOTE: When your database encoding is set to utf8mb4 and you set a field length > 191 characters,
+                     * MySQL will throw an error, BUT it won't roll back the changes, because ALTER/CREATE table commands are
+                     * implicit commands.
+                     *
+                     * https://bugs.mysql.com/bug.php?id=28727
+                     * https://github.com/TryGhost/knex-migrator/issues/51
+                     */
+                    if (err.code === 'ER_TOO_LONG_KEY') {
+                        let match = err.message.match(/`\w+`/g);
+                        let table = match[0];
+                        let field = match[2];
+
+                        throw new errors.MigrationScriptError({
+                            message: 'Field length of %field% in %table% is too long!'
+                                .replace('%field%', field)
+                                .replace('%table%', table),
+                            context:
+                                'This usually happens if your database encoding is utf8mb4.\n' +
+                                'All unique fields and indexes must be lower than 191 characters.\n' +
+                                'Please correct your field length and reset your database with `pnpm knex-migrator reset`.\n',
+                            help: 'Read more here: https://github.com/TryGhost/knex-migrator/issues/51\n',
+                            err: err,
+                        });
+                    }
+
+                    throw new errors.MigrationScriptError({
+                        message: err.message,
+                        help:
+                            'Error occurred while executing the following migration: ' + task.name,
+                        context: task,
+                        err: err,
                     });
                 });
-            }
-
-            return task.up({
-                connection: self.connection
-            });
-        }).then(function () {
-            if (hooks.afterEach) {
-                return hooks.afterEach({
-                    connection: self.connection
-                });
-            }
-        }).then(function () {
-            return self._afterEach({
-                task: task,
-                version: version
-            });
-        }).catch(function (err) {
-            if (err instanceof errors.MigrationExistsError) {
-                debug('Skipping:' + task.name);
-                skippedTasks.push(task.name);
-                return Promise.resolve();
-            }
-
-            /**
-             * @NOTE: When your database encoding is set to utf8mb4 and you set a field length > 191 characters,
-             * MySQL will throw an error, BUT it won't roll back the changes, because ALTER/CREATE table commands are
-             * implicit commands.
-             *
-             * https://bugs.mysql.com/bug.php?id=28727
-             * https://github.com/TryGhost/knex-migrator/issues/51
-             */
-            if (err.code === 'ER_TOO_LONG_KEY') {
-                let match = err.message.match(/`\w+`/g);
-                let table = match[0];
-                let field = match[2];
-
-                throw new errors.MigrationScriptError({
-                    message: 'Field length of %field% in %table% is too long!'.replace('%field%', field).replace('%table%', table),
-                    context: 'This usually happens if your database encoding is utf8mb4.\n' +
-                        'All unique fields and indexes must be lower than 191 characters.\n' +
-                        'Please correct your field length and reset your database with `pnpm knex-migrator reset`.\n',
-                    help: 'Read more here: https://github.com/TryGhost/knex-migrator/issues/51\n',
-                    err: err
-                });
-            }
-
-            throw new errors.MigrationScriptError({
-                message: err.message,
-                help: 'Error occurred while executing the following migration: ' + task.name,
-                context: task,
-                err: err
-            });
-        });
-    })).then(function () {
+        }),
+    ).then(function () {
         return {
-            skippedTasks: skippedTasks
+            skippedTasks: skippedTasks,
         };
     });
 };
@@ -1059,16 +1110,15 @@ KnexMigrator.prototype._beforeEach = function _beforeEach(options) {
     let task = options.task,
         version = options.version;
 
-    return this.connection('migrations')
-        .then(function (migrations) {
-            if (!migrations.length) {
-                return;
-            }
+    return this.connection('migrations').then(function (migrations) {
+        if (!migrations.length) {
+            return;
+        }
 
-            if (_.find(migrations, {name: task, version: version})) {
-                throw new errors.MigrationExistsError();
-            }
-        });
+        if (_.find(migrations, { name: task, version: version })) {
+            throw new errors.MigrationExistsError();
+        }
+    });
 };
 
 /**
@@ -1087,12 +1137,11 @@ KnexMigrator.prototype._afterEach = function _afterEach(options) {
     let task = options.task;
     let version = options.version;
 
-    return this.connection('migrations')
-        .insert({
-            name: task.name,
-            version: version,
-            currentVersion: self.currentVersion
-        });
+    return this.connection('migrations').insert({
+        name: task.name,
+        version: version,
+        currentVersion: self.currentVersion,
+    });
 };
 
 /**
@@ -1120,16 +1169,17 @@ KnexMigrator.prototype._integrityCheck = async function _integrityCheck(options)
 
     // CASE: no subfolder yet. You can tell knex-migrator if scripts live on a sub folder.
     try {
-        folders = folders.concat(utils.readVersionFolders(path.join(self.migrationPath, subfolder)));
-    } catch (err) {
+        folders = folders.concat(
+            utils.readVersionFolders(path.join(self.migrationPath, subfolder)),
+        );
+    } catch {
         // ignore
     }
 
     try {
-        const dbMigrations = await this
-            .connection('migrations')
+        const dbMigrations = await this.connection('migrations')
             .select('version')
-            .count('version', {as: 'c'})
+            .count('version', { as: 'c' })
             .groupBy('version');
 
         _.each(folders, function (folder) {
@@ -1137,7 +1187,7 @@ KnexMigrator.prototype._integrityCheck = async function _integrityCheck(options)
             if (folder !== 'init') {
                 try {
                     folder = folder.match(/([\d._]+)/)[0];
-                } catch (err) {
+                } catch {
                     logging.warn('Cannot parse folder name.');
                     logging.warn('Ignore Folder: ' + folder);
                     return;
@@ -1148,7 +1198,12 @@ KnexMigrator.prototype._integrityCheck = async function _integrityCheck(options)
             // if your current version is 1.0 and you add migration scripts for the next version 1.1
             // we won't execute them until your current version changes to 1.1 or until you force KM to migrate to it
             if (self.currentVersion && !force) {
-                if (utils.isGreaterThanVersion({smallerVersion: self.currentVersion, greaterVersion: folder})) {
+                if (
+                    utils.isGreaterThanVersion({
+                        smallerVersion: self.currentVersion,
+                        greaterVersion: folder,
+                    })
+                ) {
                     futureVersions.push(folder);
                 }
             }
@@ -1156,7 +1211,7 @@ KnexMigrator.prototype._integrityCheck = async function _integrityCheck(options)
             let actual = 0;
             let expected;
 
-            const migrationCount = dbMigrations.find(m => m.version === folder);
+            const migrationCount = dbMigrations.find((m) => m.version === folder);
             if (migrationCount) {
                 actual = migrationCount.c;
             }
@@ -1172,7 +1227,7 @@ KnexMigrator.prototype._integrityCheck = async function _integrityCheck(options)
 
             toReturn[folder] = {
                 expected: expected,
-                actual: actual
+                actual: actual,
             };
         });
 
@@ -1181,8 +1236,14 @@ KnexMigrator.prototype._integrityCheck = async function _integrityCheck(options)
             _.each(futureVersions, function (futureVersion) {
                 if (toReturn[futureVersion].actual !== toReturn[futureVersion].expected) {
                     logging.warn('knex-migrator is skipping ' + futureVersion);
-                    logging.warn('Current version in MigratorConfig.js is smaller then requested version, use --force to proceed!');
-                    logging.warn('Please run `pnpm knex-migrator migrate --v ' + futureVersion + ' --force` to proceed!');
+                    logging.warn(
+                        'Current version in MigratorConfig.js is smaller then requested version, use --force to proceed!',
+                    );
+                    logging.warn(
+                        'Please run `pnpm knex-migrator migrate --v ' +
+                            futureVersion +
+                            ' --force` to proceed!',
+                    );
                     delete toReturn[futureVersion];
                 }
             });
@@ -1195,7 +1256,7 @@ KnexMigrator.prototype._integrityCheck = async function _integrityCheck(options)
             throw new errors.DatabaseIsNotOkError({
                 message: 'Please define a target database in your configuration.',
                 help: 'database: {\n\tconnection:\n\t\tdatabase:"database_name"\n\t}\n}\n',
-                code: 'DB_NOT_INITIALISED'
+                code: 'DB_NOT_INITIALISED',
             });
         }
 
@@ -1203,19 +1264,19 @@ KnexMigrator.prototype._integrityCheck = async function _integrityCheck(options)
         if (err.errno === 1049) {
             throw new errors.DatabaseIsNotOkError({
                 message: 'Please run `pnpm knex-migrator init`',
-                code: 'DB_NOT_INITIALISED'
+                code: 'DB_NOT_INITIALISED',
             });
         }
 
         // CASE: migration table does not exist
         if (
-            err.errno === 1
-            || err.errno === 1146
-            || (err.code === 'SQLITE_ERROR' && /no such table: migrations/.test(err.message))
+            err.errno === 1 ||
+            err.errno === 1146 ||
+            (err.code === 'SQLITE_ERROR' && /no such table: migrations/.test(err.message))
         ) {
             throw new errors.DatabaseIsNotOkError({
                 message: 'Please run `pnpm knex-migrator init`',
-                code: 'MIGRATION_TABLE_IS_MISSING'
+                code: 'MIGRATION_TABLE_IS_MISSING',
             });
         }
 

--- a/lib/locking.js
+++ b/lib/locking.js
@@ -14,25 +14,27 @@ module.exports.lock = function (connection) {
     return database.createTransaction(connection, function (transacting) {
         return transacting('migrations_lock')
             .where({
-                lock_key: 'km01'
+                lock_key: 'km01',
             })
             .forUpdate()
             .then(function (data) {
                 if (!data || !data.length || data[0].locked) {
                     throw new errors.MigrationsAreLockedError({
-                        message: 'Migrations are running at the moment. Please wait that the lock get`s released.',
-                        context: 'Either the release was never released because of a e.g. died process or a parallel process is migrating at the moment.',
-                        help: 'If your database looks okay, you can manually release the lock by running `UPDATE migrations_lock set locked=0 where lock_key=\'km01\';`.'
+                        message:
+                            'Migrations are running at the moment. Please wait that the lock get`s released.',
+                        context:
+                            'Either the release was never released because of a e.g. died process or a parallel process is migrating at the moment.',
+                        help: "If your database looks okay, you can manually release the lock by running `UPDATE migrations_lock set locked=0 where lock_key='km01';`.",
                     });
                 }
 
                 return (transacting || connection)('migrations_lock')
                     .where({
-                        lock_key: 'km01'
+                        lock_key: 'km01',
                     })
                     .update({
                         locked: 1,
-                        acquired_at: moment().format('YYYY-MM-DD HH:mm:ss')
+                        acquired_at: moment().format('YYYY-MM-DD HH:mm:ss'),
                     });
             })
             .catch(function (err) {
@@ -42,7 +44,7 @@ module.exports.lock = function (connection) {
 
                 throw new errors.LockError({
                     message: 'Error while acquire the migration lock.',
-                    err: err
+                    err: err,
                 });
             });
     });
@@ -55,13 +57,14 @@ module.exports.lock = function (connection) {
 module.exports.isLocked = function (connection) {
     return connection('migrations_lock')
         .where({
-            lock_key: 'km01'
+            lock_key: 'km01',
         })
         .then(function (data) {
             if (!data || !data.length || data[0].locked) {
                 throw new errors.MigrationsAreLockedError({
-                    message: 'Migration lock was never released or currently a migration is running.',
-                    help: 'If you are sure no migration is running, check your data and if your database is in a broken state, you could run `pnpm knex-migrator rollback`.'
+                    message:
+                        'Migration lock was never released or currently a migration is running.',
+                    help: 'If you are sure no migration is running, check your data and if your database is in a broken state, you could run `pnpm knex-migrator rollback`.',
                 });
             }
 
@@ -80,23 +83,23 @@ module.exports.unlock = function (connection) {
     return database.createTransaction(connection, function (transacting) {
         return transacting('migrations_lock')
             .where({
-                lock_key: 'km01'
+                lock_key: 'km01',
             })
             .forUpdate()
             .then(function (data) {
                 if (!data || !data.length || !data[0].locked) {
                     throw new errors.MigrationsAreLockedError({
-                        message: 'Migration lock was already released?.'
+                        message: 'Migration lock was already released?.',
                     });
                 }
 
                 return transacting('migrations_lock')
                     .where({
-                        lock_key: 'km01'
+                        lock_key: 'km01',
                     })
                     .update({
                         locked: 0,
-                        released_at: moment().format('YYYY-MM-DD HH:mm:ss')
+                        released_at: moment().format('YYYY-MM-DD HH:mm:ss'),
                     });
             })
             .catch(function (err) {
@@ -106,7 +109,7 @@ module.exports.unlock = function (connection) {
 
                 throw new errors.UnlockError({
                     message: 'Error while releasing the migration lock.',
-                    err: err
+                    err: err,
                 });
             });
     });

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -38,17 +38,17 @@ module.exports.loadConfig = function loadConfig(options) {
         if (err.code === 'MODULE_NOT_FOUND') {
             throw new errors.KnexMigrateError({
                 message: 'Please provide a file named MigratorConfig.js in your project root.',
-                help: 'Read through the README.md to see which values are expected.'
+                help: 'Read through the README.md to see which values are expected.',
             });
         }
 
-        throw new errors.KnexMigrateError({err: err});
+        throw new errors.KnexMigrateError({ err: err });
     }
 
     try {
         return require(resolvedConfigPath);
     } catch (err) {
-        throw new errors.KnexMigrateError({err: err});
+        throw new errors.KnexMigrateError({ err: err });
     }
 };
 
@@ -63,10 +63,10 @@ exports.listFiles = function listFiles(absolutePath) {
 
     try {
         files = fs.readdirSync(absolutePath);
-    } catch (err) {
+    } catch {
         throw new errors.KnexMigrateError({
             code: 'MIGRATION_PATH',
-            message: 'MigrationPath is wrong: ' + absolutePath
+            message: 'MigrationPath is wrong: ' + absolutePath,
         });
     }
 
@@ -99,7 +99,7 @@ exports.readTasks = function readTasks(absolutePath) {
                 up: executeFn.up,
                 down: executeFn.down,
                 config: executeFn.config,
-                name: file
+                name: file,
             });
         } catch (err) {
             debug(err.message);
@@ -107,7 +107,7 @@ exports.readTasks = function readTasks(absolutePath) {
             throw new errors.MigrationScript({
                 message: err.message,
                 help: 'Cannot load Migrationscript.',
-                context: file
+                context: file,
             });
         }
     });
@@ -128,10 +128,10 @@ exports.readVersionFolders = function readFolders(absolutePath) {
 
     try {
         folders = fs.readdirSync(absolutePath);
-    } catch (err) {
+    } catch {
         throw new errors.KnexMigrateError({
             message: 'MigrationPath is wrong: ' + absolutePath,
-            code: 'READ_FOLDERS'
+            code: 'READ_FOLDERS',
         });
     }
 
@@ -180,7 +180,7 @@ exports.readVersionFolders = function readFolders(absolutePath) {
 exports.getKnexMigrator = function getKnexMigrator(options) {
     options = options || {};
 
-    return resolve('knex-migrator', {basedir: options.path})
+    return resolve('knex-migrator', { basedir: options.path })
         .then(function (localCLIPath) {
             return require(localCLIPath);
         })

--- a/loggingrc.js
+++ b/loggingrc.js
@@ -2,5 +2,5 @@ module.exports = {
     env: process.env.NODE_ENV,
     mode: 'long',
     level: 'info',
-    transports: ['stdout', 'stderr']
+    transports: ['stdout', 'stderr'],
 };

--- a/migrations/add-primary-key-to-lock-table.js
+++ b/migrations/add-primary-key-to-lock-table.js
@@ -9,11 +9,10 @@ function hasPrimaryKeySQLite(tableName, knex) {
         throw new Error('Must use hasPrimaryKeySQLite on an SQLite3 database');
     }
 
-    return knex.raw(`PRAGMA index_list('${tableName}');`)
-        .then((rawConstraints) => {
-            const tablePrimaryKey = rawConstraints.find(c => c.origin === 'pk');
-            return tablePrimaryKey;
-        });
+    return knex.raw(`PRAGMA index_list('${tableName}');`).then((rawConstraints) => {
+        const tablePrimaryKey = rawConstraints.find((c) => c.origin === 'pk');
+        return tablePrimaryKey;
+    });
 }
 
 /**
@@ -21,28 +20,33 @@ function hasPrimaryKeySQLite(tableName, knex) {
  */
 function addPrimaryKey(tableName, columns, knex) {
     if (DatabaseInfo.isSQLite(knex)) {
-        return hasPrimaryKeySQLite(tableName, knex)
-            .then((primaryKeyExists) => {
-                if (primaryKeyExists) {
-                    debug(`Primary key constraint for: ${columns} already exists for table: ${tableName}`);
-                    return;
-                }
+        return hasPrimaryKeySQLite(tableName, knex).then((primaryKeyExists) => {
+            if (primaryKeyExists) {
+                debug(
+                    `Primary key constraint for: ${columns} already exists for table: ${tableName}`,
+                );
+                return;
+            }
 
-                return knex.schema.table(tableName, function (table) {
-                    table.primary(columns);
-                });
+            return knex.schema.table(tableName, function (table) {
+                table.primary(columns);
             });
+        });
     }
 
-    return knex.schema.table(tableName, function (table) {
-        table.primary(columns);
-    }).catch((err) => {
-        if (err.code === 'ER_MULTIPLE_PRI_KEY') {
-            debug(`Primary key constraint for: ${columns} already exists for table: ${tableName}`);
-            return;
-        }
-        throw err;
-    });
+    return knex.schema
+        .table(tableName, function (table) {
+            table.primary(columns);
+        })
+        .catch((err) => {
+            if (err.code === 'ER_MULTIPLE_PRI_KEY') {
+                debug(
+                    `Primary key constraint for: ${columns} already exists for table: ${tableName}`,
+                );
+                return;
+            }
+            throw err;
+        });
 }
 
 /**

--- a/migrations/field-length.js
+++ b/migrations/field-length.js
@@ -7,16 +7,17 @@ const debug = require('debug')('knex-migrator:field-length');
 module.exports.up = function (connection) {
     debug('Ensure Field Length.');
 
-    return connection.schema.hasTable('migrations')
-        .then(function (exists) {
-            if (exists) {
-                return connection.schema.alterTable('migrations', function (table) {
+    return connection.schema.hasTable('migrations').then(function (exists) {
+        if (exists) {
+            return connection.schema
+                .alterTable('migrations', function (table) {
                     table.string('name', 120).nullable(false).alter();
                     table.string('version', 70).nullable(false).alter();
-                }).catch(function () {
+                })
+                .catch(function () {
                     // ignore for now, it's not a urgent, required change
                     return Promise.resolve();
                 });
-            }
-        });
+        }
+    });
 };

--- a/migrations/lock-table.js
+++ b/migrations/lock-table.js
@@ -8,34 +8,37 @@ const errors = require('../lib/errors');
 module.exports.up = function (connection) {
     debug('Ensure Lock Table.');
 
-    return connection.schema.hasTable('migrations_lock')
-        .then(function (table) {
-            if (table) {
-                return;
-            }
+    return connection.schema.hasTable('migrations_lock').then(function (table) {
+        if (table) {
+            return;
+        }
 
-            return connection.schema.createTable('migrations_lock', function (table) {
+        return connection.schema
+            .createTable('migrations_lock', function (table) {
                 table.string('lock_key', 191).nullable(false).primary();
                 table.boolean('locked').default(0);
                 table.dateTime('acquired_at').nullable();
                 table.dateTime('released_at').nullable();
-            }).then(function () {
-                return connection('migrations_lock')
-                    .insert({
-                        lock_key: 'km01',
-                        locked: 0
-                    });
-            }).catch(function (err) {
+            })
+            .then(function () {
+                return connection('migrations_lock').insert({
+                    lock_key: 'km01',
+                    locked: 0,
+                });
+            })
+            .catch(function (err) {
                 // CASE: sqlite db is locked (e.g. concurrent migrations are running)
                 if (err.errno === 5) {
                     throw new errors.MigrationsAreLockedError({
-                        message: 'Migrations are running at the moment. Please wait that the lock get`s released.',
-                        context: 'Either the release was never released because of a e.g. died process or a parallel process is migrating at the moment.',
-                        help: 'If you know what you are doing, you can manually release the lock by running `UPDATE migrations_lock set locked=0 where lock_key=\'km01\';`.'
+                        message:
+                            'Migrations are running at the moment. Please wait that the lock get`s released.',
+                        context:
+                            'Either the release was never released because of a e.g. died process or a parallel process is migrating at the moment.',
+                        help: "If you know what you are doing, you can manually release the lock by running `UPDATE migrations_lock set locked=0 where lock_key='km01';`.",
                     });
                 }
 
                 throw err;
             });
-        });
+    });
 };

--- a/migrations/use-index.js
+++ b/migrations/use-index.js
@@ -7,18 +7,18 @@ const debug = require('debug')('knex-migrator:use-index');
 module.exports.up = function (connection) {
     debug('Ensure Unique Index.');
 
-    return connection.schema.hasTable('migrations')
-        .then(function (exists) {
-            if (exists) {
-                return connection.schema.alterTable('migrations', function (table) {
+    return connection.schema.hasTable('migrations').then(function (exists) {
+        if (exists) {
+            return connection.schema
+                .alterTable('migrations', function (table) {
                     table.unique(['name', 'version']);
-                }).catch(function () {
+                })
+                .catch(function () {
                     // @NOTE: ignore for now, it's not a urgent, required change
                     // e.g. index exists already (1061,1)
                     // e.g. can't index because of already existing duplicates
                     return Promise.resolve();
                 });
-            }
-        });
+        }
+    });
 };
-

--- a/package.json
+++ b/package.json
@@ -28,7 +28,9 @@
   "main": "lib",
   "license": "MIT",
   "scripts": {
-    "lint": "eslint --ext .js --cache lib/** test/**",
+    "lint": "oxlint --quiet && oxfmt --check .",
+    "lint:fix": "oxlint --fix && oxfmt .",
+    "format": "oxfmt .",
     "test": "LEVEL=fatal _mocha --require test/utils.js --exit -- test/**/*_spec.js",
     "test:unit": "pnpm lint && LEVEL=fatal _mocha --require test/utils.js --report lcovonly -- test/unit/*_spec.js",
     "smoke:ghost": "node scripts/ghost-consumer-smoke.js",
@@ -70,10 +72,10 @@
     "loggingrc.js"
   ],
   "devDependencies": {
-    "eslint": "6.8.0",
-    "eslint-plugin-ghost": "0.2.0",
     "mocha": "11.7.6",
     "nyc": "18.0.0",
+    "oxfmt": "0.57.0",
+    "oxlint": "1.72.0",
     "rimraf": "6.1.3",
     "should": "13.2.3",
     "sinon": "22.0.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,18 +48,18 @@ importers:
         specifier: 1.22.12
         version: 1.22.12
     devDependencies:
-      eslint:
-        specifier: 6.8.0
-        version: 6.8.0(supports-color@8.1.1)
-      eslint-plugin-ghost:
-        specifier: 0.2.0
-        version: 0.2.0(eslint@6.8.0(supports-color@8.1.1))(supports-color@8.1.1)
       mocha:
         specifier: 11.7.6
         version: 11.7.6
       nyc:
         specifier: 18.0.0
         version: 18.0.0(supports-color@8.1.1)
+      oxfmt:
+        specifier: 0.57.0
+        version: 0.57.0
+      oxlint:
+        specifier: 1.72.0
+        version: 1.72.0
       rimraf:
         specifier: 6.1.3
         version: 6.1.3
@@ -154,9 +154,6 @@ packages:
     resolution: {integrity: sha512-/SXVuVnuU5b4dq8OFY4izG+dmGla185PcoqgK6+AJMpmOeY1QYVNbWtCwvSvoAANN5D/wV+EBU8+x7Vf9EphbA==}
     engines: {node: '>=16'}
 
-  '@ember-data/rfc395-data@0.0.4':
-    resolution: {integrity: sha512-tGRdvgC9/QMQSuSuJV45xoyhI0Pzjm7A9o/MVVA3HakXIImJbbzx/k/6dO9CUEQXIyS2y0fW6C1XaYOG7rY0FQ==}
-
   '@fastify/busboy@2.1.1':
     resolution: {integrity: sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==}
     engines: {node: '>=14'}
@@ -195,6 +192,250 @@ packages:
 
   '@keyv/serialize@1.1.1':
     resolution: {integrity: sha512-dXn3FZhPv0US+7dtJsIi2R+c7qWYiReoEh5zUntWCf4oSpMNib8FDhSoed6m3QyZdx5hK7iLFkYk3rNxwt8vTA==}
+
+  '@oxfmt/binding-android-arm-eabi@0.57.0':
+    resolution: {integrity: sha512-qVBsEO+KugOsCmUHcO8iqNnqc65p7PCKpCs8M66mPZ+Ri+CWbcpoQOEJBg2OTu03+0qu++NK1jj6IzvQVs0Sig==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [android]
+
+  '@oxfmt/binding-android-arm64@0.57.0':
+    resolution: {integrity: sha512-mp6PibWbao3aizijcheOeHQaYEhcUAt8pwLniYbtLfHxL/psFF0BykAwCj+s3c6qIpa8yN8keZICWrqtZ70w8g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@oxfmt/binding-darwin-arm64@0.57.0':
+    resolution: {integrity: sha512-T+0stuCBqmUVY+aMIvrgXhzGhHO3sD5tNiiEcYqgSdPsnukskQqn2u5qOVD0sv1l7RLdFS5Z/f5Wi9Ktyjr3Eg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@oxfmt/binding-darwin-x64@0.57.0':
+    resolution: {integrity: sha512-O+3JbqWs/mCI2oi4xfhRO2IVPFJNDDEBV8Odo+ZpmsUOeKJfjXoNH7nDmBEQcDgK7NfjDIyE7kRgYSZcTLDO0A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@oxfmt/binding-freebsd-x64@0.57.0':
+    resolution: {integrity: sha512-pxwhxVC+JkLX9twOQ/8C/vbuOQcMZyKIDmiRDZfO7yITuVcIdZCiLRqqf4QOxb2+8FWrRXzQpm+1DBKcMpHSSQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@oxfmt/binding-linux-arm-gnueabihf@0.57.0':
+    resolution: {integrity: sha512-pxBU4zH2imB/MDBfth2rOMeVxXUMjRQLCazagwLARIFH3hVlxZJBlM4nSnHXaIHJK4/qezoFCIORN6AY8Mra4A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxfmt/binding-linux-arm-musleabihf@0.57.0':
+    resolution: {integrity: sha512-JAprOzt8tycYou36ZgEw14DlRHTiN8qdtKANdV3VZIRIvTI/lh/cX13c9pJ/EnDk2GT3FASH7KvCgQ2AufAifQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxfmt/binding-linux-arm64-gnu@0.57.0':
+    resolution: {integrity: sha512-ajtjaxSaj9xl4BW7REt+Cef/ttzbAq00Bq4z7JUDZEfgFXdwSjH8K9bF+IcIJzZB9lKqMfQ4eHuSFOvvlvtqOg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxfmt/binding-linux-arm64-musl@0.57.0':
+    resolution: {integrity: sha512-p4Y/+RYk9Bk5WO+zHSUXAClRmZ2fbJCejMuCAsU2HhyME4jqf6Ftt/mJYEwIah1wGCBDYOB7wEGV1x5bCEZ6hA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxfmt/binding-linux-ppc64-gnu@0.57.0':
+    resolution: {integrity: sha512-By6tRALAZsno0F4zedmtG+wdMvJiJmJoXM4d3+A9zHE4HRXLqXITwRH8mgrlcXc5yJM2g2W3riRPwTYdgemZLQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxfmt/binding-linux-riscv64-gnu@0.57.0':
+    resolution: {integrity: sha512-skYeG+RgvyzspqVEBsEprL90OYYZfoVNqB3HcCNR6QDJyXKOzfDRT3zncnHmUaFluIlBHuY23mU1b5WGgR98hA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxfmt/binding-linux-riscv64-musl@0.57.0':
+    resolution: {integrity: sha512-FFgACrZOXAXUh5KQh2mt1CDOVOZmn+QzHP71wM9QobNwyQvoFfyAeefVUltW83g3sm7LTiH3yfFqLLVUpA5ZFQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxfmt/binding-linux-s390x-gnu@0.57.0':
+    resolution: {integrity: sha512-Nm/BAOfQeFiiKd502mZn/GAVKJwtd0RdCg17G3Wz/WSOIQmDi3+7/SZH4BHn1Ye5KvTVH3ua8WvfwLLycNIuvA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxfmt/binding-linux-x64-gnu@0.57.0':
+    resolution: {integrity: sha512-BiSy5Ku3mQqyxS6YIqAJgd403wEUWvI7kerfzPxc2l/txZVmZM0pSj7oDM+4bGBExowxOi7o73jEam1W0EDTZg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxfmt/binding-linux-x64-musl@0.57.0':
+    resolution: {integrity: sha512-BCRkJiotz5s9afLYD2LuMvzAoDYx9H17E/YbDyu4xK7l4zHDPeny9ErSXL//i/nJyaOwRk08x4b8cgJC00+JDg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxfmt/binding-openharmony-arm64@0.57.0':
+    resolution: {integrity: sha512-4Oaxe1qrGgXfpCJ1C/ERJ2iCtV2rN1R79ga9fsfyVHfSQRu/hVW780u2KDqZWFZ/iGTHODJji0JemxqFZ63eIQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@oxfmt/binding-win32-arm64-msvc@0.57.0':
+    resolution: {integrity: sha512-MYLAsDnhdNsSGheLYhWgbk0vfIrlS84iQYun/y21fX6u0jj8iBtYtbpZMdiqYeuf8U12eVPUjVY2xE2NrCfJ0g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@oxfmt/binding-win32-ia32-msvc@0.57.0':
+    resolution: {integrity: sha512-PBwdzZALJY/jcCx2E6is0yu+cuVXeySTDmwuseD+9j0mHqlRNxwlKgsyRTBed/woPeqfVfuXfWjoq4Cx2Zt3Eg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ia32]
+    os: [win32]
+
+  '@oxfmt/binding-win32-x64-msvc@0.57.0':
+    resolution: {integrity: sha512-bQJdH9i4RRfw55jm7+8/xS7GzHLLTbHx4huhrrDxQJaJtbSDbsyOnODvP1ftT7EG0KFKAYO2S+q6AcioXODx8w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@oxlint/binding-android-arm-eabi@1.72.0':
+    resolution: {integrity: sha512-zhCmvn+1Mj3UchAc/90i99S0t7jJUsHmFVSPg4UWrjO8b8eaSGwscgO6QAUtvHBstkjQwBttQNswEnAF1mIQdA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [android]
+
+  '@oxlint/binding-android-arm64@1.72.0':
+    resolution: {integrity: sha512-mtH+aY/ozv1eZoCUC2owjFAtyNBKHpJHygKeEu9zXXnQGW1Q2/qOpvx+I+Lf23+TvTz66F4iiXUbl2cGvoLPCQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@oxlint/binding-darwin-arm64@1.72.0':
+    resolution: {integrity: sha512-EvnajNPDtfknB3ZieeOOyDTwJn9QXDiwfnF4ZDQqART6RG6hjY4WigQcZdGoK2dkB3e1vrmEzN9aYbQCUkh/gQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@oxlint/binding-darwin-x64@1.72.0':
+    resolution: {integrity: sha512-ZkCdEa/G80A7vEHfeCDz/+L3m33DE73v32mDKhgOIgz8Uwf0DFcK7+uu6qC+7LEhmz5fpOe1osWKyjSNMydFIQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@oxlint/binding-freebsd-x64@1.72.0':
+    resolution: {integrity: sha512-NroXv2vh+sxVY1uya/rM5pjhx1hm8BzlYpx9q67QP0Xhw5MH2bf5GJylpvLEC+781p1Xli/317EoV9AlGwViag==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@oxlint/binding-linux-arm-gnueabihf@1.72.0':
+    resolution: {integrity: sha512-0NDywYgfj279Ou/BcQuCYSj7NJwBfmWn5qc5uGO/Ny7fUWmXyIpvawqX/8acQlWG6IXelJsJhj+JAy6sjsKj0A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxlint/binding-linux-arm-musleabihf@1.72.0':
+    resolution: {integrity: sha512-4vpXB06h65Ezsy4hRyrGjGrfa1SkVPii09yaajiYhmVpgsFiLD+KNxIx/BNAY+XiO+i1yqp9HHdwqM8VTqa5XQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxlint/binding-linux-arm64-gnu@1.72.0':
+    resolution: {integrity: sha512-immaN4g2ZGFiOkKrvRX9LvzZdd2GkQM5wR+UyzYyUuyhUTXGQ4HKUJH18xp4G8OfhCVaVAJfKZxwE1r8+4hhaQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxlint/binding-linux-arm64-musl@1.72.0':
+    resolution: {integrity: sha512-JGHS9Mnr7iWyyLDxgCv1MhzVpAckgptg00F2gnxt/GD7lQ2SW1BRcxHqhSTaSdDpjWRrBkBxMMh4+Hn3aVtExg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxlint/binding-linux-ppc64-gnu@1.72.0':
+    resolution: {integrity: sha512-AOYgBZqxNshrg83P9v0RYv+m8s10Cqkj4/PxXFDhcS3k7FqsIG5+CxErshZCIN7G8iy4Y+VGfAsuEdar8AcbBg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxlint/binding-linux-riscv64-gnu@1.72.0':
+    resolution: {integrity: sha512-QMybPS5ij3/vrKG67mqzHwW++91sYxK/PPUVi6SBtNCEzW4niS52fVBdXbQ6nou0wWbUPEpx8Sl/ZjtgE3clXA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxlint/binding-linux-riscv64-musl@1.72.0':
+    resolution: {integrity: sha512-gOc3W7JV0PXRpIL7stUlLe3Wa9Gp0Kdlup87IT3gHDvPKck2xNgMIl/Gs2lldYY2lyXZDC4rWi3hmoLUobkgbQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxlint/binding-linux-s390x-gnu@1.72.0':
+    resolution: {integrity: sha512-rpGxph+FjjHcYI5q6uxB3Az+tnfmEnDbSA8+PK9ZE/VzyUAkvBOMeuY7ZQMhu5mpZH7YQDsTdW6Cx4kV/msc6w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxlint/binding-linux-x64-gnu@1.72.0':
+    resolution: {integrity: sha512-WND+uhf/Ko13SLqQMWQUgsZuLvYYEvL0ZKgg0tgGYfLqxG7l8Ju123fHDMJyYSDl5E3bUbpFUuii/OvMreFQzw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxlint/binding-linux-x64-musl@1.72.0':
+    resolution: {integrity: sha512-SrpbrUL70nG9vh6zP4/oKHWgLuHquwsr7MW9XOn0olBVgh10Uqr8qscKhQoBGEn6olK/IUpn5GSKcdQ5AjUhGA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxlint/binding-openharmony-arm64@1.72.0':
+    resolution: {integrity: sha512-qkrsEn6NmgFKr7U/QnezQMb+q/vzAy0Dd9Y95gQGQTyjzDLN+HRZMuM5u70iyH4nBLCfKBzhjMsYCehKay2jyg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@oxlint/binding-win32-arm64-msvc@1.72.0':
+    resolution: {integrity: sha512-LWR6ZlFZph+KPjXv8opgZsXRDCdrdQe8VL8Cg9zxCoBS73h6znzZpydVgmdnwj8mB9AuSM5jxEgDJDpQkjboeg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@oxlint/binding-win32-ia32-msvc@1.72.0':
+    resolution: {integrity: sha512-yt6HEh7IsHvtjRWtmeZRX134eaXKHq5Gnqlf1xBJdJl1JtdoRUEJw3nAxpZoUDS860cX/foKbztO441anVBtVQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ia32]
+    os: [win32]
+
+  '@oxlint/binding-win32-x64-msvc@1.72.0':
+    resolution: {integrity: sha512-b2eKFD2hX7tIwmo/cyH6TDq8vzWRZ2qNHrzoGntUTmq0h3zQh/uX3eTSHCwI8OB/ADQfJCRelLItK8BsxuucDA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
 
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
@@ -1043,43 +1284,12 @@ packages:
     resolution: {integrity: sha512-a1wflyaL0tHtJSmLSOVybYhy22vRih4eduhhrkcjgrWGnRfrZtovJ2FRjxuTtkkj47O/baf0R86QU5OuYpz8fA==}
     engines: {node: ^20.17.0 || >=22.9.0}
 
-  acorn-jsx@5.3.2:
-    resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
-    peerDependencies:
-      acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
-
-  acorn@6.4.2:
-    resolution: {integrity: sha512-XtGIhXwF8YM8bJhGxG5kXgjkEuNGLTkoYqVE+KMR+aspr4KGYmKYg7yUe3KghyQ9yheNwLnjmzh/7+gfDBmHCQ==}
-    engines: {node: '>=0.4.0'}
-    hasBin: true
-
-  acorn@7.4.1:
-    resolution: {integrity: sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==}
-    engines: {node: '>=0.4.0'}
-    hasBin: true
-
   aggregate-error@3.1.0:
     resolution: {integrity: sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==}
     engines: {node: '>=8'}
 
   ajv@6.15.0:
     resolution: {integrity: sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==}
-
-  ansi-escapes@3.2.0:
-    resolution: {integrity: sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==}
-    engines: {node: '>=4'}
-
-  ansi-escapes@4.3.2:
-    resolution: {integrity: sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==}
-    engines: {node: '>=8'}
-
-  ansi-regex@3.0.1:
-    resolution: {integrity: sha512-+O9Jct8wf++lXxxFc4hc8LsjaSq0HFzzL7cVsw8pRDIPdjKD2mT4ytDZlLuSBZ4cLKZFXIrMGO7DbQCtMJJMKw==}
-    engines: {node: '>=4'}
-
-  ansi-regex@4.1.1:
-    resolution: {integrity: sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==}
-    engines: {node: '>=6'}
 
   ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
@@ -1088,10 +1298,6 @@ packages:
   ansi-regex@6.2.2:
     resolution: {integrity: sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==}
     engines: {node: '>=12'}
-
-  ansi-styles@3.2.1:
-    resolution: {integrity: sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==}
-    engines: {node: '>=4'}
 
   ansi-styles@4.3.0:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
@@ -1120,10 +1326,6 @@ packages:
   assert-plus@1.0.0:
     resolution: {integrity: sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==}
     engines: {node: '>=0.8'}
-
-  astral-regex@1.0.0:
-    resolution: {integrity: sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==}
-    engines: {node: '>=4'}
 
   async@3.2.6:
     resolution: {integrity: sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==}
@@ -1217,10 +1419,6 @@ packages:
   caller@1.1.0:
     resolution: {integrity: sha512-n+21IZC3j06YpCWaxmUy5AnVqhmCIM2bQtqQyy00HJlmStRt6kwDX5F9Z97pqwAB+G/tgSz6q/kUBbNyQzIubw==}
 
-  callsites@3.1.0:
-    resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
-    engines: {node: '>=6'}
-
   camelcase@5.3.1:
     resolution: {integrity: sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==}
     engines: {node: '>=6'}
@@ -1235,16 +1433,9 @@ packages:
   caseless@0.12.0:
     resolution: {integrity: sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==}
 
-  chalk@2.4.2:
-    resolution: {integrity: sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==}
-    engines: {node: '>=4'}
-
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
-
-  chardet@0.7.0:
-    resolution: {integrity: sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==}
 
   chokidar@4.0.3:
     resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
@@ -1261,21 +1452,6 @@ packages:
     resolution: {integrity: sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==}
     engines: {node: '>=6'}
 
-  cli-cursor@2.1.0:
-    resolution: {integrity: sha512-8lgKz8LmCRYZZQDpRyT2m5rKJ08TnU4tR9FFFW2rxpxR1FzWi4PQ/NfyODchAatHaUgnSPVcx/R5w6NuTBzFiw==}
-    engines: {node: '>=4'}
-
-  cli-cursor@3.1.0:
-    resolution: {integrity: sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==}
-    engines: {node: '>=8'}
-
-  cli-width@2.2.1:
-    resolution: {integrity: sha512-GRMWDxpOB6Dgk2E5Uo+3eEBvtOOlimMmpbFiKuLFnQzYDavtLFY3K5ona41jgN/WdRZtG7utuVSVTL4HbZHGkw==}
-
-  cli-width@3.0.0:
-    resolution: {integrity: sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw==}
-    engines: {node: '>= 10'}
-
   cliui@6.0.0:
     resolution: {integrity: sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==}
 
@@ -1286,15 +1462,9 @@ packages:
     resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
     engines: {node: '>=12'}
 
-  color-convert@1.9.3:
-    resolution: {integrity: sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==}
-
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
     engines: {node: '>=7.0.0'}
-
-  color-name@1.1.3:
-    resolution: {integrity: sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==}
 
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
@@ -1335,10 +1505,6 @@ packages:
 
   core-util-is@1.0.2:
     resolution: {integrity: sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==}
-
-  cross-spawn@6.0.6:
-    resolution: {integrity: sha512-VqCUuhcd1iB+dsv8gxPttb5iZh/D0iubSP21g36KXdEuf6I5JiioesUVjpCdHV9MZRUfVFlvwtIUyPfxo5trtw==}
-    engines: {node: '>=4.8'}
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -1398,9 +1564,6 @@ packages:
     resolution: {integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==}
     engines: {node: '>=4.0.0'}
 
-  deep-is@0.1.4:
-    resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
-
   default-require-extensions@3.0.1:
     resolution: {integrity: sha512-eXTJmRbm2TIt9MgWTsOH1wEuhew6XGZcMeGKCtLedIg/NCsg1iBePXkceTdK4Fii7pzmN9tGsZhKzZ4h7O/fxw==}
     engines: {node: '>=8'}
@@ -1425,10 +1588,6 @@ packages:
     resolution: {integrity: sha512-svtcdpS8CgJyqAjEQIXdb3OjhFVVYjzGAPO8WGCmRbrml64SPw/jJD4GoE98aR7r25A0XcgrK3F02yw9R/vhQw==}
     engines: {node: '>=0.3.1'}
 
-  doctrine@3.0.0:
-    resolution: {integrity: sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==}
-    engines: {node: '>=6.0.0'}
-
   dtrace-provider@0.8.8:
     resolution: {integrity: sha512-b7Z7cNtHPhH9EJhNNbbeqTcXB8LGFFZhq1PGgEvpeHlzd36bhbdTWoE/Ba/YguqpBSlAPKnARWhVlhunCMwfxg==}
     engines: {node: '>=0.10'}
@@ -1441,12 +1600,6 @@ packages:
 
   electron-to-chromium@1.5.382:
     resolution: {integrity: sha512-8ETaWbV6SZOrno+G93Ffd9ENsMtetqdnqj4nlfxFW90Sm5GgnuV28Kf62hqQVD6VUgzm7qFQKsTsAPmeUiU3Ug==}
-
-  ember-rfc176-data@0.3.18:
-    resolution: {integrity: sha512-JtuLoYGSjay1W3MQAxt3eINWXNYYQliK90tLwtb8aeCuQK8zKGCRbBodVIrkcTqshULMnRuTOS6t1P7oQk3g6Q==}
-
-  emoji-regex@7.0.3:
-    resolution: {integrity: sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==}
 
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
@@ -1472,90 +1625,18 @@ packages:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
 
-  escape-string-regexp@1.0.5:
-    resolution: {integrity: sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==}
-    engines: {node: '>=0.8.0'}
-
   escape-string-regexp@4.0.0:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
-
-  eslint-plugin-ember@6.10.1:
-    resolution: {integrity: sha512-RZI0+UoR4xeD6UE3KQCUwbN2nZOIIPaFCCXqBIRXDr0rFuwvknAHqYtDPJVZicvTzNHa4TEZvAKqfbE8t7SztQ==}
-    engines: {node: '>=6.0'}
-
-  eslint-plugin-ghost@0.2.0:
-    resolution: {integrity: sha512-yHZlNYClLqYx6vF3gg4O7/18MmKyPND58WGaLduMmGDtS5iifHK9jnVukQprOHyJdxrSSOZWll/6duasctxU2A==}
-    peerDependencies:
-      eslint: '>=0.8.0'
-
-  eslint-plugin-sort-imports-es6-autofix@0.4.0:
-    resolution: {integrity: sha512-LyqXwY0TIu997NdTbSPtTo3KgGRrpMLni4AUxqbQqkhE/kS+KXXngHoiW5c1PTaLgmHO6siBb90v1TCtyqBu/Q==}
-
-  eslint-scope@4.0.3:
-    resolution: {integrity: sha512-p7VutNr1O/QrxysMo3E45FjYDTeXBy0iTltPFNSqKAIfjDSXC+4dj+qfyuD8bfAXrW/y6lW3O76VaYNPKfpKrg==}
-    engines: {node: '>=4.0.0'}
-
-  eslint-scope@5.1.1:
-    resolution: {integrity: sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==}
-    engines: {node: '>=8.0.0'}
-
-  eslint-utils@1.4.3:
-    resolution: {integrity: sha512-fbBN5W2xdY45KulGXmLHZ3c3FHfVYmKg0IrAKGOkT/464PQsx2UeIzfz1RmEci+KLm1bBaAzZAh8+/E+XAeZ8Q==}
-    engines: {node: '>=6'}
-
-  eslint-visitor-keys@1.3.0:
-    resolution: {integrity: sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==}
-    engines: {node: '>=4'}
-
-  eslint@5.16.0:
-    resolution: {integrity: sha512-S3Rz11i7c8AA5JPv7xAH+dOyq/Cu/VXHiHXBPOU1k/JAM5dXqQPt3qcrhpHSorXmrpu2g0gkIBVXAqCpzfoZIg==}
-    engines: {node: ^6.14.0 || ^8.10.0 || >=9.10.0}
-    deprecated: This version is no longer supported. Please see https://eslint.org/version-support for other options.
-    hasBin: true
-
-  eslint@6.8.0:
-    resolution: {integrity: sha512-K+Iayyo2LtyYhDSYwz5D5QdWw0hCacNzyq1Y821Xna2xSJj7cijoLLYmLxTQgcgZ9mC61nryMy9S7GRbYpI5Ig==}
-    engines: {node: ^8.10.0 || ^10.13.0 || >=11.10.1}
-    deprecated: This version is no longer supported. Please see https://eslint.org/version-support for other options.
-    hasBin: true
 
   esm@3.2.25:
     resolution: {integrity: sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA==}
     engines: {node: '>=6'}
 
-  espree@5.0.1:
-    resolution: {integrity: sha512-qWAZcWh4XE/RwzLJejfcofscgMc9CamR6Tn1+XRXNzrvUSSbiAjGOI/fggztjIi7y9VLPqnICMIPiGyr8JaZ0A==}
-    engines: {node: '>=6.0.0'}
-
-  espree@6.2.1:
-    resolution: {integrity: sha512-ysCxRQY3WaXJz9tdbWOwuWr5Y/XrPTGX9Kiz3yoUXwW0VZ4w30HTkQLaGx/+ttFjF8i+ACbArnB4ce68a9m5hw==}
-    engines: {node: '>=6.0.0'}
-
   esprima@4.0.1:
     resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
     engines: {node: '>=4'}
     hasBin: true
-
-  esquery@1.7.0:
-    resolution: {integrity: sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==}
-    engines: {node: '>=0.10'}
-
-  esrecurse@4.3.0:
-    resolution: {integrity: sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==}
-    engines: {node: '>=4.0'}
-
-  estraverse@4.3.0:
-    resolution: {integrity: sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==}
-    engines: {node: '>=4.0'}
-
-  estraverse@5.3.0:
-    resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
-    engines: {node: '>=4.0'}
-
-  esutils@2.0.3:
-    resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
-    engines: {node: '>=0.10.0'}
 
   expand-template@2.0.3:
     resolution: {integrity: sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==}
@@ -1567,10 +1648,6 @@ packages:
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
 
-  external-editor@3.1.0:
-    resolution: {integrity: sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==}
-    engines: {node: '>=4'}
-
   extsprintf@1.3.0:
     resolution: {integrity: sha512-11Ndz7Nv+mvAC1j0ktTa7fAb0vLyGGX+rMHNBYQviQDGU0Hw7lhctJANqbPhu9nV9/izT/IntTgZ7Im/9LJs9g==}
     engines: {'0': node >=0.6.0}
@@ -1581,9 +1658,6 @@ packages:
   fast-json-stable-stringify@2.1.0:
     resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
 
-  fast-levenshtein@2.0.6:
-    resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
-
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
     engines: {node: '>=12.0.0'}
@@ -1592,18 +1666,6 @@ packages:
     peerDependenciesMeta:
       picomatch:
         optional: true
-
-  figures@2.0.0:
-    resolution: {integrity: sha512-Oa2M9atig69ZkfwiApY8F2Yy+tzMbazyvqv21R0NsSC8floSOC09BbT1ITWAdoMGQvJ/aZnR1KMwdx9tvHnTNA==}
-    engines: {node: '>=4'}
-
-  figures@3.2.0:
-    resolution: {integrity: sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==}
-    engines: {node: '>=8'}
-
-  file-entry-cache@5.0.1:
-    resolution: {integrity: sha512-bCg29ictuBaKUwwArK4ouCaqDgLZcysCFLmM/Yn/FDoqndh/9vNuQfXRDvTuXKLxfD/JtZQGKFT8MGcJBK644g==}
-    engines: {node: '>=4'}
 
   file-uri-to-path@1.0.0:
     resolution: {integrity: sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==}
@@ -1623,16 +1685,9 @@ packages:
     resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
     engines: {node: '>=10'}
 
-  flat-cache@2.0.1:
-    resolution: {integrity: sha512-LoQe6yDuUMDzQAEH8sgmh4Md6oZnc/7PjtwjNFSzveXqSHt6ka9fPBuso7IGf9Rz4uqnSnWiFH2B/zj24a5ReA==}
-    engines: {node: '>=4'}
-
   flat@5.0.2:
     resolution: {integrity: sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==}
     hasBin: true
-
-  flatted@2.0.2:
-    resolution: {integrity: sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==}
 
   foreground-child@2.0.0:
     resolution: {integrity: sha512-dCIq9FpEcyQyXKCkyzmlPTFNgrCzPudOe+mhvJU5zAtlBnGVy2yKxtfsxK2tQBThwq225jcvBjpw1Gr40uzZCA==}
@@ -1663,14 +1718,8 @@ packages:
     resolution: {integrity: sha512-w8ZNZr2mKIc7qeNaQ9AVPT1+iFaI+Avd4xudVOvdDJ8VytREi1Ft5Ih7hd9jjehod8vAM5GMsfQ/TpPf4EyoEA==}
     engines: {node: '>=14.14'}
 
-  fs.realpath@1.0.0:
-    resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
-
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
-
-  functional-red-black-tree@1.0.1:
-    resolution: {integrity: sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g==}
 
   gelf-stream@1.1.1:
     resolution: {integrity: sha512-kCzCfI6DJ8+aaDhwMcsNm2l6CsBj6y4Is6CCxH2W9sYnZGcXg9WmJ/iZMoJVO6uTwTRL7dbIioAS8lCuGUXSFA==}
@@ -1706,10 +1755,6 @@ packages:
   github-from-package@0.0.0:
     resolution: {integrity: sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==}
 
-  glob-parent@5.1.2:
-    resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
-    engines: {node: '>= 6'}
-
   glob@10.5.0:
     resolution: {integrity: sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==}
     deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
@@ -1722,18 +1767,6 @@ packages:
   glob@6.0.4:
     resolution: {integrity: sha512-MKZeRNyYZAVVVG1oZeLaWie1uweH40m9AZwIwxyPbTSX4hHrVYSzLg0Ro5Z5R7XKkIX+Cc6oD1rqeDJnwsB8/A==}
     deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
-
-  glob@7.2.3:
-    resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
-    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
-
-  globals@11.12.0:
-    resolution: {integrity: sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==}
-    engines: {node: '>=4'}
-
-  globals@12.4.0:
-    resolution: {integrity: sha512-BWICuzzDvDoH54NHKCseDanAhE3CeDorgDL5MT6LMXXj2WCnd9UC2szdk4AWLfjdgNBCXLUanXYcpBBKOSWGwg==}
-    engines: {node: '>=8'}
 
   got@14.6.6:
     resolution: {integrity: sha512-QLV1qeYSo5l13mQzWgP/y0LbMr5Plr5fJilgAIwgnwseproEbtNym8xpLsDzeZ6MWXgNE6kdWGBjdh3zT/Qerg==}
@@ -1750,10 +1783,6 @@ packages:
     resolution: {integrity: sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==}
     engines: {node: '>=6'}
     deprecated: this library is no longer supported
-
-  has-flag@3.0.0:
-    resolution: {integrity: sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==}
-    engines: {node: '>=4'}
 
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
@@ -1789,24 +1818,12 @@ packages:
     resolution: {integrity: sha512-V5nVw1PAOgfI3Lmeaj2Exmeg7fenjhRUgz1lPSezy1CuhPYbgQtbQj4jZfEAEMlaL+vupsvhjqCyjzob0yxsmQ==}
     engines: {node: '>=10.19.0'}
 
-  iconv-lite@0.4.24:
-    resolution: {integrity: sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==}
-    engines: {node: '>=0.10.0'}
-
   iconv-lite@0.7.2:
     resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
     engines: {node: '>=0.10.0'}
 
   ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
-
-  ignore@4.0.6:
-    resolution: {integrity: sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==}
-    engines: {node: '>= 4'}
-
-  import-fresh@3.3.1:
-    resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
-    engines: {node: '>=6'}
 
   imurmurhash@0.1.4:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
@@ -1830,14 +1847,6 @@ packages:
     resolution: {integrity: sha512-7PnF4oN3CvZF23ADhA5wRaYEQpJ8qygSkbtTXWBeXWXmEVRXK+1ITciHWwHhsjv1TmW0MgacIv6hEi5pX5NQdA==}
     engines: {node: '>=10'}
 
-  inquirer@6.5.2:
-    resolution: {integrity: sha512-cntlB5ghuB0iuO65Ovoi8ogLHiWGs/5yNrtUcKjFhSSiVeAIVpD7koaSU9RM8mpXw5YDi9RdYXGQMaOURB7ycQ==}
-    engines: {node: '>=6.0.0'}
-
-  inquirer@7.3.3:
-    resolution: {integrity: sha512-JG3eIAj5V9CwcGvuOmoo6LB9kbAYT8HXffUl6memuszlwDC/qvFAJw49XJ5NROSFNPxp3iQg1GqkFhaY/CR0IA==}
-    engines: {node: '>=8.0.0'}
-
   interpret@2.2.0:
     resolution: {integrity: sha512-Ju0Bz/cEia55xDwUWEa8+olFpCiQoypjnQySseKtmjNrnps3P+xfpUmGr90T7yjlVJmOtybRvPXhKMbHr+fWnw==}
     engines: {node: '>= 0.10'}
@@ -1846,21 +1855,9 @@ packages:
     resolution: {integrity: sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==}
     engines: {node: '>= 0.4'}
 
-  is-extglob@2.1.1:
-    resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
-    engines: {node: '>=0.10.0'}
-
-  is-fullwidth-code-point@2.0.0:
-    resolution: {integrity: sha512-VHskAKYM8RfSFXwee5t5cbN5PZeq1Wrh6qd5bkyiXIf6UQcN6w/A0eXM9r6t8d+GYOh+o6ZhiEnb88LN/Y8m2w==}
-    engines: {node: '>=4'}
-
   is-fullwidth-code-point@3.0.0:
     resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
     engines: {node: '>=8'}
-
-  is-glob@4.0.3:
-    resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
-    engines: {node: '>=0.10.0'}
 
   is-path-inside@3.0.3:
     resolution: {integrity: sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==}
@@ -1958,9 +1955,6 @@ packages:
   json-schema@0.4.0:
     resolution: {integrity: sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==}
 
-  json-stable-stringify-without-jsonify@1.0.1:
-    resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
-
   json-stringify-safe@5.0.1:
     resolution: {integrity: sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==}
 
@@ -2007,10 +2001,6 @@ packages:
       tedious:
         optional: true
 
-  levn@0.3.0:
-    resolution: {integrity: sha512-0OO4y2iOHix2W6ujICbKIaEQXvFQHue65vUG3pb5EUomzPI90z9hsA1VsO/dbIIpC53J8gxM9Q4Oho0jrCM/yA==}
-    engines: {node: '>= 0.8.0'}
-
   locate-path@5.0.0:
     resolution: {integrity: sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==}
     engines: {node: '>=8'}
@@ -2045,9 +2035,6 @@ packages:
   long@5.3.2:
     resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
 
-  lower-case@1.1.4:
-    resolution: {integrity: sha512-2Fgx1Ycm599x+WGpIYwJOvsjmXFzTSc34IwDWALRA/8AopUKAVPwfJ+h5+f85BCp0PWmmJcWzEpxOpoXycMpdA==}
-
   lowercase-keys@3.0.0:
     resolution: {integrity: sha512-ozCC6gdQ+glXOQsveKD0YsDy8DSQFjDTz4zyzEHNV5+JP5D62LmfDZ6o1cycFx9ouG940M5dE8C8CTewdj2YWQ==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
@@ -2081,14 +2068,6 @@ packages:
   mime-types@2.1.35:
     resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
     engines: {node: '>= 0.6'}
-
-  mimic-fn@1.2.0:
-    resolution: {integrity: sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==}
-    engines: {node: '>=4'}
-
-  mimic-fn@2.1.0:
-    resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==}
-    engines: {node: '>=6'}
 
   mimic-response@3.1.0:
     resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
@@ -2147,12 +2126,6 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
-  mute-stream@0.0.7:
-    resolution: {integrity: sha512-r65nCZhrbXXb6dXOACihYApHw2Q6pV0M3V0PSxd74N0+D8nzAdEAITq2oAjA1jVnKI+tGvEBUpqiMh0+rW6zDQ==}
-
-  mute-stream@0.0.8:
-    resolution: {integrity: sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==}
-
   mv@2.1.1:
     resolution: {integrity: sha512-at/ZndSy3xEGJ8i0ygALh8ru9qy7gWW1cmkaqBN29JmMlIvM//MEO9y1sk/avxuwnPcfhkejkLsuPxH81BrkSg==}
     engines: {node: '>=0.8.0'}
@@ -2173,9 +2146,6 @@ packages:
   napi-build-utils@2.0.0:
     resolution: {integrity: sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==}
 
-  natural-compare@1.4.0:
-    resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
-
   nconf@0.13.0:
     resolution: {integrity: sha512-hJ/u2xCpA663h6xyOiztx3y+lg9eU0rdkwJ+c4FtiHo2g/gB0sjXtW31yTdMLWLOIj1gL2FcJMwfOqouuUK/Wg==}
     engines: {node: '>= 0.4.0'}
@@ -2183,12 +2153,6 @@ packages:
   ncp@2.0.0:
     resolution: {integrity: sha512-zIdGUrPRFTUELUvr3Gmc7KZ2Sw/h1PiVM0Af/oHB6zgnV1ikqSfRk+TOufi79aHYCW3NiOXmr1BP5nWbzojLaA==}
     hasBin: true
-
-  nice-try@1.0.5:
-    resolution: {integrity: sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==}
-
-  no-case@2.3.2:
-    resolution: {integrity: sha512-rmTZ9kz+f3rCvK2TD1Ue/oZlns7OGoIWP4fc3llxxRXlOkHKoWPPWJOfFYpITabSow43QJbRIoHQXtt10VldyQ==}
 
   node-abi@3.92.0:
     resolution: {integrity: sha512-KdHvFWZjEKDf0cakgFjebl371GPsISX2oZHcuyKqM7DtogIsHrqKeLTo8wBHxaXRAQlY2PsPlZmfo+9ZCxEREQ==}
@@ -2235,21 +2199,31 @@ packages:
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
-  onetime@2.0.1:
-    resolution: {integrity: sha512-oyyPpiMaKARvvcgip+JV+7zci5L8D1W9RZIz2l1o08AM3pfspitVWnPt3mzHcBPp12oYMTy0pqrFs/C+m3EwsQ==}
-    engines: {node: '>=4'}
+  oxfmt@0.57.0:
+    resolution: {integrity: sha512-ZB7Bi+rGDSqmVIo9jwcLyFgjxXvQhDdU+jx+ZrVy6VRiVXK2+CHc4hO3J4dUQjHe7V0ymHB+MDuv5z+NhK07HA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      svelte: ^5.0.0
+      vite-plus: '*'
+    peerDependenciesMeta:
+      svelte:
+        optional: true
+      vite-plus:
+        optional: true
 
-  onetime@5.1.2:
-    resolution: {integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==}
-    engines: {node: '>=6'}
-
-  optionator@0.8.3:
-    resolution: {integrity: sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==}
-    engines: {node: '>= 0.8.0'}
-
-  os-tmpdir@1.0.2:
-    resolution: {integrity: sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==}
-    engines: {node: '>=0.10.0'}
+  oxlint@1.72.0:
+    resolution: {integrity: sha512-1rhdZIP/EvoI91ABIwNU5Q8+bWf8mjrS5UzIOZld4d4bXxJvtlUhlQvaoTogIGin/qdErMOrwaIJvCSIAKTLhA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      oxlint-tsgolint: '>=0.22.1'
+      vite-plus: '*'
+    peerDependenciesMeta:
+      oxlint-tsgolint:
+        optional: true
+      vite-plus:
+        optional: true
 
   p-cancelable@4.0.1:
     resolution: {integrity: sha512-wBowNApzd45EIKdO1LaU+LrMBwAcjfPaYtVzV3lmfM3gf8Z4CHZsiIqlM8TZZ8okYvh5A1cP6gTfCRQtwUpaUg==}
@@ -2286,10 +2260,6 @@ packages:
   package-json-from-dist@1.0.1:
     resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
 
-  parent-module@1.0.1:
-    resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
-    engines: {node: '>=6'}
-
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
@@ -2297,13 +2267,6 @@ packages:
   path-is-absolute@1.0.1:
     resolution: {integrity: sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==}
     engines: {node: '>=0.10.0'}
-
-  path-is-inside@1.0.2:
-    resolution: {integrity: sha512-DUWJr3+ULp4zXmol/SZkFf3JGsS9/SIv+Y3Rt93/UjPpDpklB5f1er4O3POIbUuUJ3FXgqte2Q7SrU6zAqwk8w==}
-
-  path-key@2.0.1:
-    resolution: {integrity: sha512-fEHGKCSmUSDPv4uoj8AlD+joPlq3peND+HRYyxFz4KPw4z926S/b8rIuFs2FYJg3BwsxJf6A9/3eIdLaYC+9Dw==}
-    engines: {node: '>=4'}
 
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
@@ -2343,10 +2306,6 @@ packages:
     deprecated: No longer maintained. Please contact the author of the relevant native addon; alternatives are available.
     hasBin: true
 
-  prelude-ls@1.1.2:
-    resolution: {integrity: sha512-ESF23V4SKG6lVSGZgYNpbsiaAkdab6ZgOxe52p7+Kid3W3u3bxR4Vfd/o21dmN7jSt0IwgZ4v5MUd26FEtXE9w==}
-    engines: {node: '>= 0.8.0'}
-
   prettyjson@1.2.5:
     resolution: {integrity: sha512-rksPWtoZb2ZpT5OVgtmy0KHVM+Dca3iVwWY9ifwhcexfjebtgjg3wmrUt9PvJ59XIYBcknQeYHD8IAnVlh9lAw==}
     hasBin: true
@@ -2358,10 +2317,6 @@ packages:
   process-on-spawn@1.1.0:
     resolution: {integrity: sha512-JOnOPQ/8TZgjs1JIH/m9ni7FfimjNa/PRx7y/Wb5qdItsnhO0jE4AT7fC0HjC28DUQWDr50dwSYZLdRMlqDq3Q==}
     engines: {node: '>=8'}
-
-  progress@2.0.3:
-    resolution: {integrity: sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==}
-    engines: {node: '>=0.4.0'}
 
   psl@1.15.0:
     resolution: {integrity: sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==}
@@ -2400,10 +2355,6 @@ packages:
     resolution: {integrity: sha512-/vxpCXddiX8NGfGO/mTafwjq4aFa/71pvamip0++IQk3zG8cbCj0fifNPrjjF1XMXUne91jL9OoxmdykoEtifQ==}
     engines: {node: '>= 10.13.0'}
 
-  regexpp@2.0.1:
-    resolution: {integrity: sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw==}
-    engines: {node: '>=6.5.0'}
-
   release-zalgo@1.0.0:
     resolution: {integrity: sha512-gUAyHVHPPC5wdqX/LG4LWtRYtgjxyX78oanFNTMMyFEfOqdC54s3eE82imuWKbOeqYht2CrNf64Qb8vgmmtZGA==}
     engines: {node: '>=4'}
@@ -2423,10 +2374,6 @@ packages:
   resolve-alpn@1.2.1:
     resolution: {integrity: sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==}
 
-  resolve-from@4.0.0:
-    resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
-    engines: {node: '>=4'}
-
   resolve-from@5.0.0:
     resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
     engines: {node: '>=8'}
@@ -2440,21 +2387,8 @@ packages:
     resolution: {integrity: sha512-cGk8IbWEAnaCpdAt1BHzJ3Ahz5ewDJa0KseTsE3qIRMJ3C698W8psM7byCeWVpd/Ha7FUYzuRVzXoKoM6nRUbA==}
     engines: {node: '>=20'}
 
-  restore-cursor@2.0.0:
-    resolution: {integrity: sha512-6IzJLuGi4+R14vwagDHX+JrXmPVtPpn4mffDJ1UdR7/Edm87fl6yi8mMBIVvFtJaNTUvjughmW4hwLhRG7gC1Q==}
-    engines: {node: '>=4'}
-
-  restore-cursor@3.1.0:
-    resolution: {integrity: sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==}
-    engines: {node: '>=8'}
-
   rimraf@2.4.5:
     resolution: {integrity: sha512-J5xnxTyqaiw06JjMftq7L9ouA448dw/E7dKghkP9WpKNuwmARNNg+Gk8/u5ryb9N/Yo2+z3MCwuqFK/+qPOPfQ==}
-    deprecated: Rimraf versions prior to v4 are no longer supported
-    hasBin: true
-
-  rimraf@2.6.3:
-    resolution: {integrity: sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==}
     deprecated: Rimraf versions prior to v4 are no longer supported
     hasBin: true
 
@@ -2462,14 +2396,6 @@ packages:
     resolution: {integrity: sha512-LKg+Cr2ZF61fkcaK1UdkH2yEBBKnYjTyWzTJT6KNPcSPaiT7HSdhtMXQuN5wkTX0Xu72KQ1l8S42rlmexS2hSA==}
     engines: {node: 20 || >=22}
     hasBin: true
-
-  run-async@2.4.1:
-    resolution: {integrity: sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==}
-    engines: {node: '>=0.12.0'}
-
-  rxjs@6.6.7:
-    resolution: {integrity: sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==}
-    engines: {npm: '>=2.0.0'}
 
   safe-buffer@5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
@@ -2486,10 +2412,6 @@ packages:
   secure-keys@1.0.0:
     resolution: {integrity: sha512-nZi59hW3Sl5P3+wOO89eHBAAGwmCPd2aE1+dLZV5MO+ItQctIvAqihzaAXIQhvtH4KJPxM080HsnqltR2y8cWg==}
 
-  semver@5.7.2:
-    resolution: {integrity: sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==}
-    hasBin: true
-
   semver@6.3.1:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
     hasBin: true
@@ -2505,17 +2427,9 @@ packages:
   set-blocking@2.0.0:
     resolution: {integrity: sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==}
 
-  shebang-command@1.2.0:
-    resolution: {integrity: sha512-EV3L1+UQWGor21OmnvojK36mhg+TyIKDh3iFBKBohr5xeXIhNBcx8oWdgkTEEQ+BEFFYdLRuqMfd5L84N1V5Vg==}
-    engines: {node: '>=0.10.0'}
-
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
     engines: {node: '>=8'}
-
-  shebang-regex@1.0.0:
-    resolution: {integrity: sha512-wpoSFAxys6b2a2wHZ1XpDSgD7N9iVjg29Ph9uV/uaP9Ex/KXlkTZTeddxDPSYQpgvzKLGJke2UU0AzoGCjNIvQ==}
-    engines: {node: '>=0.10.0'}
 
   shebang-regex@3.0.0:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
@@ -2555,13 +2469,6 @@ packages:
   sinon@22.0.0:
     resolution: {integrity: sha512-sq/6DpdXOrLyfbKlXLg/Usc7xu8YXPeLkOFZRvA3bNUSA2lhbrZ06yuXbH1fkzBPCbz9O10+7hznzUsjaYNm0Q==}
 
-  slice-ansi@2.1.0:
-    resolution: {integrity: sha512-Qu+VC3EwYLldKa1fCxuuvULvSJOKEgk9pi8dZeCVK7TqBfUNTH4sFkk4joj8afVSfAYgJoSOetjx9QWOJ5mYoQ==}
-    engines: {node: '>=6'}
-
-  snake-case@2.1.0:
-    resolution: {integrity: sha512-FMR5YoPFwOLuh4rRz92dywJjyKYZNLpMn1R5ujVpIYkbA9p01fq8RMg0FkO4M+Yobt4MjHeLTJVm5xFFBHSV2Q==}
-
   source-map@0.6.1:
     resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
@@ -2590,14 +2497,6 @@ packages:
     engines: {node: '>=0.10.0'}
     hasBin: true
 
-  string-width@2.1.1:
-    resolution: {integrity: sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==}
-    engines: {node: '>=4'}
-
-  string-width@3.1.0:
-    resolution: {integrity: sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==}
-    engines: {node: '>=6'}
-
   string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
     engines: {node: '>=8'}
@@ -2608,14 +2507,6 @@ packages:
 
   string_decoder@1.3.0:
     resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
-
-  strip-ansi@4.0.0:
-    resolution: {integrity: sha512-4XaJ2zQdCzROZDivEVIDPkcQn8LMFSa8kj8Gxb/Lnwzv9A8VctNZ+lfivC/sV3ivW8ElJTERXZoPBRrZKkNKow==}
-    engines: {node: '>=4'}
-
-  strip-ansi@5.2.0:
-    resolution: {integrity: sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==}
-    engines: {node: '>=6'}
 
   strip-ansi@6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
@@ -2637,10 +2528,6 @@ packages:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
 
-  supports-color@5.5.0:
-    resolution: {integrity: sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==}
-    engines: {node: '>=4'}
-
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
@@ -2652,10 +2539,6 @@ packages:
   supports-preserve-symlinks-flag@1.0.0:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
-
-  table@5.4.6:
-    resolution: {integrity: sha512-wmEc8m4fjnob4gt5riFRtTu/6+4rSe12TpAELNSqHMfF3IqnA+CH37USM6/YR3qRZv7e56kAEAtd6nKZaxe0Ug==}
-    engines: {node: '>=6.0.0'}
 
   tar-fs@2.1.5:
     resolution: {integrity: sha512-OboTd8mmMhZDNPV+UjQcK9yKAatXu2aJ+r1w4im1Otd4M4fl2hwvdoXUxIYHFTHWK/3y3FarBP70v3vwmGlOxw==}
@@ -2676,12 +2559,6 @@ packages:
     resolution: {integrity: sha512-ZOffsNrXYggvU1mDGHk54I96r26P8SyMjO5slMKSc7+IWmtB/MQKnEC2fP51imB3/pT6YK5cT5E8f+Dd9KdyOQ==}
     engines: {node: 20 || >=22}
 
-  text-table@0.2.0:
-    resolution: {integrity: sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==}
-
-  through@2.3.8:
-    resolution: {integrity: sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==}
-
   tildify@2.0.0:
     resolution: {integrity: sha512-Cc+OraorugtXNfs50hU9KS369rFXCfgGLpfCfvlc+Ud5u6VWmUQsOAa9HbTvheQdYnrdJqqv1e5oIqXppMYnSw==}
     engines: {node: '>=8'}
@@ -2690,16 +2567,13 @@ packages:
     resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
     engines: {node: '>=12.0.0'}
 
-  tmp@0.0.33:
-    resolution: {integrity: sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==}
-    engines: {node: '>=0.6.0'}
+  tinypool@2.1.0:
+    resolution: {integrity: sha512-Pugqs6M0m7Lv1I7FtxN4aoyToKg1C4tu+/381vH35y8oENM/Ai7f7C4StcoK4/+BSw9ebcS8jRiVrORFKCALLw==}
+    engines: {node: ^20.0.0 || >=22.0.0}
 
   tough-cookie@2.5.0:
     resolution: {integrity: sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==}
     engines: {node: '>=0.8'}
-
-  tslib@1.14.1:
-    resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
@@ -2710,10 +2584,6 @@ packages:
   tweetnacl@0.14.5:
     resolution: {integrity: sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==}
 
-  type-check@0.3.2:
-    resolution: {integrity: sha512-ZCmOJdvOWDBYJlzAoFkC+Q0+bUyEOS1ltgp1MGU03fqHG+dbi9tBFU2Rd9QKiDZFAYrhPh2JUf7rZRIuHRKtOg==}
-    engines: {node: '>= 0.8.0'}
-
   type-detect@4.0.8:
     resolution: {integrity: sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==}
     engines: {node: '>=4'}
@@ -2721,10 +2591,6 @@ packages:
   type-detect@4.1.0:
     resolution: {integrity: sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==}
     engines: {node: '>=4'}
-
-  type-fest@0.21.3:
-    resolution: {integrity: sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==}
-    engines: {node: '>=10'}
 
   type-fest@0.8.1:
     resolution: {integrity: sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==}
@@ -2774,9 +2640,6 @@ packages:
     deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
-  v8-compile-cache@2.4.0:
-    resolution: {integrity: sha512-ocyWc3bAHBB/guyqJQVI5o4BZkPhznPYUG2ea80Gond/BgNWpap8TOmLSeeQG7bnh2KMISxskdADG59j7zruhw==}
-
   validator@7.2.0:
     resolution: {integrity: sha512-c8NGTUYeBEcUIGeMppmNVKHE7wwfm3mYbNZxV+c5mlv9fDHI7Ad3p07qfNrn/CvpdkK2k61fOLRO2sTEhgQXmg==}
     engines: {node: '>= 0.10'}
@@ -2788,10 +2651,6 @@ packages:
   which-module@2.0.1:
     resolution: {integrity: sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==}
 
-  which@1.3.1:
-    resolution: {integrity: sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==}
-    hasBin: true
-
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
@@ -2801,10 +2660,6 @@ packages:
     resolution: {integrity: sha512-oGLe46MIrCRqX7ytPUf66EAYvdeMIZYn3WaocqqKZAxrBpkqHfL/qvTyJ/bTk5+AqHCjXmrv3CEWgy368zhRUg==}
     engines: {node: ^20.17.0 || >=22.9.0}
     hasBin: true
-
-  word-wrap@1.2.5:
-    resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
-    engines: {node: '>=0.10.0'}
 
   workerpool@9.3.4:
     resolution: {integrity: sha512-TmPRQYYSAnnDiEB0P/Ytip7bFGvqnSU6I2BcuSw7Hx+JSg/DsUi5ebYfc8GYaSdpuvOcEs6dXxPurOYpe9QFwg==}
@@ -2826,10 +2681,6 @@ packages:
 
   write-file-atomic@3.0.3:
     resolution: {integrity: sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==}
-
-  write@1.0.3:
-    resolution: {integrity: sha512-/lg70HAjtkUgWPVZhZcm+T4hkL8Zbtp1nFNOn3lRrxnlv50SRBv7cR7RqR+GMsd3hUXy9hWBo4CHTbFTcOYwig==}
-    engines: {node: '>=4'}
 
   y18n@4.0.3:
     resolution: {integrity: sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==}
@@ -2896,7 +2747,7 @@ snapshots:
       '@babel/helpers': 7.29.7
       '@babel/parser': 7.29.7
       '@babel/template': 7.29.7
-      '@babel/traverse': 7.29.7(supports-color@8.1.1)
+      '@babel/traverse': 7.29.7
       '@babel/types': 7.29.7
       '@jridgewell/remapping': 2.3.5
       convert-source-map: 2.0.0
@@ -2927,7 +2778,7 @@ snapshots:
 
   '@babel/helper-module-imports@7.29.7':
     dependencies:
-      '@babel/traverse': 7.29.7(supports-color@8.1.1)
+      '@babel/traverse': 7.29.7
       '@babel/types': 7.29.7
     transitivePeerDependencies:
       - supports-color
@@ -2937,7 +2788,7 @@ snapshots:
       '@babel/core': 7.29.7(supports-color@8.1.1)
       '@babel/helper-module-imports': 7.29.7
       '@babel/helper-validator-identifier': 7.29.7
-      '@babel/traverse': 7.29.7(supports-color@8.1.1)
+      '@babel/traverse': 7.29.7
     transitivePeerDependencies:
       - supports-color
 
@@ -2962,7 +2813,7 @@ snapshots:
       '@babel/parser': 7.29.7
       '@babel/types': 7.29.7
 
-  '@babel/traverse@7.29.7(supports-color@8.1.1)':
+  '@babel/traverse@7.29.7':
     dependencies:
       '@babel/code-frame': 7.29.7
       '@babel/generator': 7.29.7
@@ -2996,8 +2847,6 @@ snapshots:
       undici: 5.29.0
     transitivePeerDependencies:
       - supports-color
-
-  '@ember-data/rfc395-data@0.0.4': {}
 
   '@fastify/busboy@2.1.1': {}
 
@@ -3045,6 +2894,120 @@ snapshots:
       '@jridgewell/sourcemap-codec': 1.5.5
 
   '@keyv/serialize@1.1.1': {}
+
+  '@oxfmt/binding-android-arm-eabi@0.57.0':
+    optional: true
+
+  '@oxfmt/binding-android-arm64@0.57.0':
+    optional: true
+
+  '@oxfmt/binding-darwin-arm64@0.57.0':
+    optional: true
+
+  '@oxfmt/binding-darwin-x64@0.57.0':
+    optional: true
+
+  '@oxfmt/binding-freebsd-x64@0.57.0':
+    optional: true
+
+  '@oxfmt/binding-linux-arm-gnueabihf@0.57.0':
+    optional: true
+
+  '@oxfmt/binding-linux-arm-musleabihf@0.57.0':
+    optional: true
+
+  '@oxfmt/binding-linux-arm64-gnu@0.57.0':
+    optional: true
+
+  '@oxfmt/binding-linux-arm64-musl@0.57.0':
+    optional: true
+
+  '@oxfmt/binding-linux-ppc64-gnu@0.57.0':
+    optional: true
+
+  '@oxfmt/binding-linux-riscv64-gnu@0.57.0':
+    optional: true
+
+  '@oxfmt/binding-linux-riscv64-musl@0.57.0':
+    optional: true
+
+  '@oxfmt/binding-linux-s390x-gnu@0.57.0':
+    optional: true
+
+  '@oxfmt/binding-linux-x64-gnu@0.57.0':
+    optional: true
+
+  '@oxfmt/binding-linux-x64-musl@0.57.0':
+    optional: true
+
+  '@oxfmt/binding-openharmony-arm64@0.57.0':
+    optional: true
+
+  '@oxfmt/binding-win32-arm64-msvc@0.57.0':
+    optional: true
+
+  '@oxfmt/binding-win32-ia32-msvc@0.57.0':
+    optional: true
+
+  '@oxfmt/binding-win32-x64-msvc@0.57.0':
+    optional: true
+
+  '@oxlint/binding-android-arm-eabi@1.72.0':
+    optional: true
+
+  '@oxlint/binding-android-arm64@1.72.0':
+    optional: true
+
+  '@oxlint/binding-darwin-arm64@1.72.0':
+    optional: true
+
+  '@oxlint/binding-darwin-x64@1.72.0':
+    optional: true
+
+  '@oxlint/binding-freebsd-x64@1.72.0':
+    optional: true
+
+  '@oxlint/binding-linux-arm-gnueabihf@1.72.0':
+    optional: true
+
+  '@oxlint/binding-linux-arm-musleabihf@1.72.0':
+    optional: true
+
+  '@oxlint/binding-linux-arm64-gnu@1.72.0':
+    optional: true
+
+  '@oxlint/binding-linux-arm64-musl@1.72.0':
+    optional: true
+
+  '@oxlint/binding-linux-ppc64-gnu@1.72.0':
+    optional: true
+
+  '@oxlint/binding-linux-riscv64-gnu@1.72.0':
+    optional: true
+
+  '@oxlint/binding-linux-riscv64-musl@1.72.0':
+    optional: true
+
+  '@oxlint/binding-linux-s390x-gnu@1.72.0':
+    optional: true
+
+  '@oxlint/binding-linux-x64-gnu@1.72.0':
+    optional: true
+
+  '@oxlint/binding-linux-x64-musl@1.72.0':
+    optional: true
+
+  '@oxlint/binding-openharmony-arm64@1.72.0':
+    optional: true
+
+  '@oxlint/binding-win32-arm64-msvc@1.72.0':
+    optional: true
+
+  '@oxlint/binding-win32-ia32-msvc@1.72.0':
+    optional: true
+
+  '@oxlint/binding-win32-x64-msvc@1.72.0':
+    optional: true
 
   '@pkgjs/parseargs@0.11.0':
     optional: true
@@ -4019,18 +3982,6 @@ snapshots:
   abbrev@4.0.0:
     optional: true
 
-  acorn-jsx@5.3.2(acorn@6.4.2):
-    dependencies:
-      acorn: 6.4.2
-
-  acorn-jsx@5.3.2(acorn@7.4.1):
-    dependencies:
-      acorn: 7.4.1
-
-  acorn@6.4.2: {}
-
-  acorn@7.4.1: {}
-
   aggregate-error@3.1.0:
     dependencies:
       clean-stack: 2.2.0
@@ -4043,23 +3994,9 @@ snapshots:
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
 
-  ansi-escapes@3.2.0: {}
-
-  ansi-escapes@4.3.2:
-    dependencies:
-      type-fest: 0.21.3
-
-  ansi-regex@3.0.1: {}
-
-  ansi-regex@4.1.1: {}
-
   ansi-regex@5.0.1: {}
 
   ansi-regex@6.2.2: {}
-
-  ansi-styles@3.2.1:
-    dependencies:
-      color-convert: 1.9.3
 
   ansi-styles@4.3.0:
     dependencies:
@@ -4084,8 +4021,6 @@ snapshots:
       safer-buffer: 2.1.2
 
   assert-plus@1.0.0: {}
-
-  astral-regex@1.0.0: {}
 
   async@3.2.6: {}
 
@@ -4132,6 +4067,7 @@ snapshots:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
+    optional: true
 
   brace-expansion@2.1.1:
     dependencies:
@@ -4192,8 +4128,6 @@ snapshots:
 
   caller@1.1.0: {}
 
-  callsites@3.1.0: {}
-
   camelcase@5.3.1: {}
 
   camelcase@6.3.0: {}
@@ -4202,18 +4136,10 @@ snapshots:
 
   caseless@0.12.0: {}
 
-  chalk@2.4.2:
-    dependencies:
-      ansi-styles: 3.2.1
-      escape-string-regexp: 1.0.5
-      supports-color: 5.5.0
-
   chalk@4.1.2:
     dependencies:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
-
-  chardet@0.7.0: {}
 
   chokidar@4.0.3:
     dependencies:
@@ -4226,18 +4152,6 @@ snapshots:
     optional: true
 
   clean-stack@2.2.0: {}
-
-  cli-cursor@2.1.0:
-    dependencies:
-      restore-cursor: 2.0.0
-
-  cli-cursor@3.1.0:
-    dependencies:
-      restore-cursor: 3.1.0
-
-  cli-width@2.2.1: {}
-
-  cli-width@3.0.0: {}
 
   cliui@6.0.0:
     dependencies:
@@ -4257,15 +4171,9 @@ snapshots:
       strip-ansi: 6.0.1
       wrap-ansi: 7.0.0
 
-  color-convert@1.9.3:
-    dependencies:
-      color-name: 1.1.3
-
   color-convert@2.0.1:
     dependencies:
       color-name: 1.1.4
-
-  color-name@1.1.3: {}
 
   color-name@1.1.4: {}
 
@@ -4285,21 +4193,14 @@ snapshots:
 
   compare-ver@2.0.2: {}
 
-  concat-map@0.0.1: {}
+  concat-map@0.0.1:
+    optional: true
 
   convert-source-map@1.9.0: {}
 
   convert-source-map@2.0.0: {}
 
   core-util-is@1.0.2: {}
-
-  cross-spawn@6.0.6:
-    dependencies:
-      nice-try: 1.0.5
-      path-key: 2.0.1
-      semver: 5.7.2
-      shebang-command: 1.2.0
-      which: 1.3.1
 
   cross-spawn@7.0.6:
     dependencies:
@@ -4343,8 +4244,6 @@ snapshots:
   deep-extend@0.6.0:
     optional: true
 
-  deep-is@0.1.4: {}
-
   default-require-extensions@3.0.1:
     dependencies:
       strip-bom: 4.0.0
@@ -4360,10 +4259,6 @@ snapshots:
 
   diff@9.0.0: {}
 
-  doctrine@3.0.0:
-    dependencies:
-      esutils: 2.0.3
-
   dtrace-provider@0.8.8:
     dependencies:
       nan: 2.28.0
@@ -4377,10 +4272,6 @@ snapshots:
       safer-buffer: 2.1.2
 
   electron-to-chromium@1.5.382: {}
-
-  ember-rfc176-data@0.3.18: {}
-
-  emoji-regex@7.0.3: {}
 
   emoji-regex@8.0.0: {}
 
@@ -4400,158 +4291,11 @@ snapshots:
 
   escalade@3.2.0: {}
 
-  escape-string-regexp@1.0.5: {}
-
   escape-string-regexp@4.0.0: {}
-
-  eslint-plugin-ember@6.10.1:
-    dependencies:
-      '@ember-data/rfc395-data': 0.0.4
-      ember-rfc176-data: 0.3.18
-      snake-case: 2.1.0
-
-  eslint-plugin-ghost@0.2.0(eslint@6.8.0(supports-color@8.1.1))(supports-color@8.1.1):
-    dependencies:
-      eslint: 6.8.0(supports-color@8.1.1)
-      eslint-plugin-ember: 6.10.1
-      eslint-plugin-sort-imports-es6-autofix: 0.4.0(supports-color@8.1.1)
-    transitivePeerDependencies:
-      - supports-color
-
-  eslint-plugin-sort-imports-es6-autofix@0.4.0(supports-color@8.1.1):
-    dependencies:
-      eslint: 5.16.0(supports-color@8.1.1)
-    transitivePeerDependencies:
-      - supports-color
-
-  eslint-scope@4.0.3:
-    dependencies:
-      esrecurse: 4.3.0
-      estraverse: 4.3.0
-
-  eslint-scope@5.1.1:
-    dependencies:
-      esrecurse: 4.3.0
-      estraverse: 4.3.0
-
-  eslint-utils@1.4.3:
-    dependencies:
-      eslint-visitor-keys: 1.3.0
-
-  eslint-visitor-keys@1.3.0: {}
-
-  eslint@5.16.0(supports-color@8.1.1):
-    dependencies:
-      '@babel/code-frame': 7.29.7
-      ajv: 6.15.0
-      chalk: 2.4.2
-      cross-spawn: 6.0.6
-      debug: 4.4.3(supports-color@8.1.1)
-      doctrine: 3.0.0
-      eslint-scope: 4.0.3
-      eslint-utils: 1.4.3
-      eslint-visitor-keys: 1.3.0
-      espree: 5.0.1
-      esquery: 1.7.0
-      esutils: 2.0.3
-      file-entry-cache: 5.0.1
-      functional-red-black-tree: 1.0.1
-      glob: 7.2.3
-      globals: 11.12.0
-      ignore: 4.0.6
-      import-fresh: 3.3.1
-      imurmurhash: 0.1.4
-      inquirer: 6.5.2
-      js-yaml: 3.15.0
-      json-stable-stringify-without-jsonify: 1.0.1
-      levn: 0.3.0
-      lodash: 4.18.1
-      minimatch: 3.1.5
-      mkdirp: 0.5.6
-      natural-compare: 1.4.0
-      optionator: 0.8.3
-      path-is-inside: 1.0.2
-      progress: 2.0.3
-      regexpp: 2.0.1
-      semver: 5.7.2
-      strip-ansi: 4.0.0
-      strip-json-comments: 2.0.1
-      table: 5.4.6
-      text-table: 0.2.0
-    transitivePeerDependencies:
-      - supports-color
-
-  eslint@6.8.0(supports-color@8.1.1):
-    dependencies:
-      '@babel/code-frame': 7.29.7
-      ajv: 6.15.0
-      chalk: 2.4.2
-      cross-spawn: 6.0.6
-      debug: 4.4.3(supports-color@8.1.1)
-      doctrine: 3.0.0
-      eslint-scope: 5.1.1
-      eslint-utils: 1.4.3
-      eslint-visitor-keys: 1.3.0
-      espree: 6.2.1
-      esquery: 1.7.0
-      esutils: 2.0.3
-      file-entry-cache: 5.0.1
-      functional-red-black-tree: 1.0.1
-      glob-parent: 5.1.2
-      globals: 12.4.0
-      ignore: 4.0.6
-      import-fresh: 3.3.1
-      imurmurhash: 0.1.4
-      inquirer: 7.3.3
-      is-glob: 4.0.3
-      js-yaml: 3.15.0
-      json-stable-stringify-without-jsonify: 1.0.1
-      levn: 0.3.0
-      lodash: 4.18.1
-      minimatch: 3.1.5
-      mkdirp: 0.5.6
-      natural-compare: 1.4.0
-      optionator: 0.8.3
-      progress: 2.0.3
-      regexpp: 2.0.1
-      semver: 6.3.1
-      strip-ansi: 5.2.0
-      strip-json-comments: 3.1.1
-      table: 5.4.6
-      text-table: 0.2.0
-      v8-compile-cache: 2.4.0
-    transitivePeerDependencies:
-      - supports-color
 
   esm@3.2.25: {}
 
-  espree@5.0.1:
-    dependencies:
-      acorn: 6.4.2
-      acorn-jsx: 5.3.2(acorn@6.4.2)
-      eslint-visitor-keys: 1.3.0
-
-  espree@6.2.1:
-    dependencies:
-      acorn: 7.4.1
-      acorn-jsx: 5.3.2(acorn@7.4.1)
-      eslint-visitor-keys: 1.3.0
-
   esprima@4.0.1: {}
-
-  esquery@1.7.0:
-    dependencies:
-      estraverse: 5.3.0
-
-  esrecurse@4.3.0:
-    dependencies:
-      estraverse: 5.3.0
-
-  estraverse@4.3.0: {}
-
-  estraverse@5.3.0: {}
-
-  esutils@2.0.3: {}
 
   expand-template@2.0.3:
     optional: true
@@ -4561,36 +4305,16 @@ snapshots:
 
   extend@3.0.2: {}
 
-  external-editor@3.1.0:
-    dependencies:
-      chardet: 0.7.0
-      iconv-lite: 0.4.24
-      tmp: 0.0.33
-
   extsprintf@1.3.0: {}
 
   fast-deep-equal@3.1.3: {}
 
   fast-json-stable-stringify@2.1.0: {}
 
-  fast-levenshtein@2.0.6: {}
-
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
       picomatch: 4.0.4
     optional: true
-
-  figures@2.0.0:
-    dependencies:
-      escape-string-regexp: 1.0.5
-
-  figures@3.2.0:
-    dependencies:
-      escape-string-regexp: 1.0.5
-
-  file-entry-cache@5.0.1:
-    dependencies:
-      flat-cache: 2.0.1
 
   file-uri-to-path@1.0.0:
     optional: true
@@ -4613,15 +4337,7 @@ snapshots:
       locate-path: 6.0.0
       path-exists: 4.0.0
 
-  flat-cache@2.0.1:
-    dependencies:
-      flatted: 2.0.2
-      rimraf: 2.6.3
-      write: 1.0.3
-
   flat@5.0.2: {}
-
-  flatted@2.0.2: {}
 
   foreground-child@2.0.0:
     dependencies:
@@ -4654,11 +4370,7 @@ snapshots:
       jsonfile: 6.2.1
       universalify: 2.0.1
 
-  fs.realpath@1.0.0: {}
-
   function-bind@1.1.2: {}
-
-  functional-red-black-tree@1.0.1: {}
 
   gelf-stream@1.1.1:
     dependencies:
@@ -4690,10 +4402,6 @@ snapshots:
   github-from-package@0.0.0:
     optional: true
 
-  glob-parent@5.1.2:
-    dependencies:
-      is-glob: 4.0.3
-
   glob@10.5.0:
     dependencies:
       foreground-child: 3.3.1
@@ -4718,21 +4426,6 @@ snapshots:
       path-is-absolute: 1.0.1
     optional: true
 
-  glob@7.2.3:
-    dependencies:
-      fs.realpath: 1.0.0
-      inflight: 1.0.6
-      inherits: 2.0.4
-      minimatch: 3.1.5
-      once: 1.4.0
-      path-is-absolute: 1.0.1
-
-  globals@11.12.0: {}
-
-  globals@12.4.0:
-    dependencies:
-      type-fest: 0.8.1
-
   got@14.6.6:
     dependencies:
       '@sindresorhus/is': 7.2.0
@@ -4756,8 +4449,6 @@ snapshots:
     dependencies:
       ajv: 6.15.0
       har-schema: 2.0.0
-
-  has-flag@3.0.0: {}
 
   has-flag@4.0.0: {}
 
@@ -4789,23 +4480,12 @@ snapshots:
       quick-lru: 5.1.1
       resolve-alpn: 1.2.1
 
-  iconv-lite@0.4.24:
-    dependencies:
-      safer-buffer: 2.1.2
-
   iconv-lite@0.7.2:
     dependencies:
       safer-buffer: 2.1.2
 
   ieee754@1.2.1:
     optional: true
-
-  ignore@4.0.6: {}
-
-  import-fresh@3.3.1:
-    dependencies:
-      parent-module: 1.0.1
-      resolve-from: 4.0.0
 
   imurmurhash@0.1.4: {}
 
@@ -4815,45 +4495,15 @@ snapshots:
     dependencies:
       once: 1.4.0
       wrappy: 1.0.2
+    optional: true
 
-  inherits@2.0.4: {}
+  inherits@2.0.4:
+    optional: true
 
   ini@1.3.8:
     optional: true
 
   ini@2.0.0: {}
-
-  inquirer@6.5.2:
-    dependencies:
-      ansi-escapes: 3.2.0
-      chalk: 2.4.2
-      cli-cursor: 2.1.0
-      cli-width: 2.2.1
-      external-editor: 3.1.0
-      figures: 2.0.0
-      lodash: 4.18.1
-      mute-stream: 0.0.7
-      run-async: 2.4.1
-      rxjs: 6.6.7
-      string-width: 2.1.1
-      strip-ansi: 5.2.0
-      through: 2.3.8
-
-  inquirer@7.3.3:
-    dependencies:
-      ansi-escapes: 4.3.2
-      chalk: 4.1.2
-      cli-cursor: 3.1.0
-      cli-width: 3.0.0
-      external-editor: 3.1.0
-      figures: 3.2.0
-      lodash: 4.18.1
-      mute-stream: 0.0.8
-      run-async: 2.4.1
-      rxjs: 6.6.7
-      string-width: 4.2.3
-      strip-ansi: 6.0.1
-      through: 2.3.8
 
   interpret@2.2.0: {}
 
@@ -4861,15 +4511,7 @@ snapshots:
     dependencies:
       hasown: 2.0.4
 
-  is-extglob@2.1.1: {}
-
-  is-fullwidth-code-point@2.0.0: {}
-
   is-fullwidth-code-point@3.0.0: {}
-
-  is-glob@4.0.3:
-    dependencies:
-      is-extglob: 2.1.1
 
   is-path-inside@3.0.3: {}
 
@@ -4962,8 +4604,6 @@ snapshots:
 
   json-schema@0.4.0: {}
 
-  json-stable-stringify-without-jsonify@1.0.1: {}
-
   json-stringify-safe@5.0.1: {}
 
   json5@2.2.3: {}
@@ -5008,11 +4648,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  levn@0.3.0:
-    dependencies:
-      prelude-ls: 1.1.2
-      type-check: 0.3.2
-
   locate-path@5.0.0:
     dependencies:
       p-locate: 4.1.0
@@ -5045,8 +4680,6 @@ snapshots:
 
   long@5.3.2: {}
 
-  lower-case@1.1.4: {}
-
   lowercase-keys@3.0.0: {}
 
   lru-cache@10.4.3: {}
@@ -5073,10 +4706,6 @@ snapshots:
     dependencies:
       mime-db: 1.52.0
 
-  mimic-fn@1.2.0: {}
-
-  mimic-fn@2.1.0: {}
-
   mimic-response@3.1.0:
     optional: true
 
@@ -5089,6 +4718,7 @@ snapshots:
   minimatch@3.1.5:
     dependencies:
       brace-expansion: 1.1.15
+    optional: true
 
   minimatch@9.0.9:
     dependencies:
@@ -5109,6 +4739,7 @@ snapshots:
   mkdirp@0.5.6:
     dependencies:
       minimist: 1.2.8
+    optional: true
 
   mocha@11.7.6:
     dependencies:
@@ -5146,10 +4777,6 @@ snapshots:
 
   ms@2.1.3: {}
 
-  mute-stream@0.0.7: {}
-
-  mute-stream@0.0.8: {}
-
   mv@2.1.1:
     dependencies:
       mkdirp: 0.5.6
@@ -5179,8 +4806,6 @@ snapshots:
   napi-build-utils@2.0.0:
     optional: true
 
-  natural-compare@1.4.0: {}
-
   nconf@0.13.0:
     dependencies:
       async: 3.2.6
@@ -5190,12 +4815,6 @@ snapshots:
 
   ncp@2.0.0:
     optional: true
-
-  nice-try@1.0.5: {}
-
-  no-case@2.3.2:
-    dependencies:
-      lower-case: 1.1.4
 
   node-abi@3.92.0:
     dependencies:
@@ -5275,25 +4894,53 @@ snapshots:
   once@1.4.0:
     dependencies:
       wrappy: 1.0.2
+    optional: true
 
-  onetime@2.0.1:
+  oxfmt@0.57.0:
     dependencies:
-      mimic-fn: 1.2.0
+      tinypool: 2.1.0
+    optionalDependencies:
+      '@oxfmt/binding-android-arm-eabi': 0.57.0
+      '@oxfmt/binding-android-arm64': 0.57.0
+      '@oxfmt/binding-darwin-arm64': 0.57.0
+      '@oxfmt/binding-darwin-x64': 0.57.0
+      '@oxfmt/binding-freebsd-x64': 0.57.0
+      '@oxfmt/binding-linux-arm-gnueabihf': 0.57.0
+      '@oxfmt/binding-linux-arm-musleabihf': 0.57.0
+      '@oxfmt/binding-linux-arm64-gnu': 0.57.0
+      '@oxfmt/binding-linux-arm64-musl': 0.57.0
+      '@oxfmt/binding-linux-ppc64-gnu': 0.57.0
+      '@oxfmt/binding-linux-riscv64-gnu': 0.57.0
+      '@oxfmt/binding-linux-riscv64-musl': 0.57.0
+      '@oxfmt/binding-linux-s390x-gnu': 0.57.0
+      '@oxfmt/binding-linux-x64-gnu': 0.57.0
+      '@oxfmt/binding-linux-x64-musl': 0.57.0
+      '@oxfmt/binding-openharmony-arm64': 0.57.0
+      '@oxfmt/binding-win32-arm64-msvc': 0.57.0
+      '@oxfmt/binding-win32-ia32-msvc': 0.57.0
+      '@oxfmt/binding-win32-x64-msvc': 0.57.0
 
-  onetime@5.1.2:
-    dependencies:
-      mimic-fn: 2.1.0
-
-  optionator@0.8.3:
-    dependencies:
-      deep-is: 0.1.4
-      fast-levenshtein: 2.0.6
-      levn: 0.3.0
-      prelude-ls: 1.1.2
-      type-check: 0.3.2
-      word-wrap: 1.2.5
-
-  os-tmpdir@1.0.2: {}
+  oxlint@1.72.0:
+    optionalDependencies:
+      '@oxlint/binding-android-arm-eabi': 1.72.0
+      '@oxlint/binding-android-arm64': 1.72.0
+      '@oxlint/binding-darwin-arm64': 1.72.0
+      '@oxlint/binding-darwin-x64': 1.72.0
+      '@oxlint/binding-freebsd-x64': 1.72.0
+      '@oxlint/binding-linux-arm-gnueabihf': 1.72.0
+      '@oxlint/binding-linux-arm-musleabihf': 1.72.0
+      '@oxlint/binding-linux-arm64-gnu': 1.72.0
+      '@oxlint/binding-linux-arm64-musl': 1.72.0
+      '@oxlint/binding-linux-ppc64-gnu': 1.72.0
+      '@oxlint/binding-linux-riscv64-gnu': 1.72.0
+      '@oxlint/binding-linux-riscv64-musl': 1.72.0
+      '@oxlint/binding-linux-s390x-gnu': 1.72.0
+      '@oxlint/binding-linux-x64-gnu': 1.72.0
+      '@oxlint/binding-linux-x64-musl': 1.72.0
+      '@oxlint/binding-openharmony-arm64': 1.72.0
+      '@oxlint/binding-win32-arm64-msvc': 1.72.0
+      '@oxlint/binding-win32-ia32-msvc': 1.72.0
+      '@oxlint/binding-win32-x64-msvc': 1.72.0
 
   p-cancelable@4.0.1: {}
 
@@ -5328,17 +4975,10 @@ snapshots:
 
   package-json-from-dist@1.0.1: {}
 
-  parent-module@1.0.1:
-    dependencies:
-      callsites: 3.1.0
-
   path-exists@4.0.0: {}
 
-  path-is-absolute@1.0.1: {}
-
-  path-is-inside@1.0.2: {}
-
-  path-key@2.0.1: {}
+  path-is-absolute@1.0.1:
+    optional: true
 
   path-key@3.1.1: {}
 
@@ -5383,8 +5023,6 @@ snapshots:
       tunnel-agent: 0.6.0
     optional: true
 
-  prelude-ls@1.1.2: {}
-
   prettyjson@1.2.5:
     dependencies:
       colors: 1.4.0
@@ -5396,8 +5034,6 @@ snapshots:
   process-on-spawn@1.1.0:
     dependencies:
       fromentries: 1.3.2
-
-  progress@2.0.3: {}
 
   psl@1.15.0:
     dependencies:
@@ -5440,8 +5076,6 @@ snapshots:
     dependencies:
       resolve: 1.22.12
 
-  regexpp@2.0.1: {}
-
   release-zalgo@1.0.0:
     dependencies:
       es6-error: 4.1.1
@@ -5475,8 +5109,6 @@ snapshots:
 
   resolve-alpn@1.2.1: {}
 
-  resolve-from@4.0.0: {}
-
   resolve-from@5.0.0: {}
 
   resolve@1.22.12:
@@ -5490,35 +5122,15 @@ snapshots:
     dependencies:
       lowercase-keys: 3.0.0
 
-  restore-cursor@2.0.0:
-    dependencies:
-      onetime: 2.0.1
-      signal-exit: 3.0.7
-
-  restore-cursor@3.1.0:
-    dependencies:
-      onetime: 5.1.2
-      signal-exit: 3.0.7
-
   rimraf@2.4.5:
     dependencies:
       glob: 6.0.4
     optional: true
 
-  rimraf@2.6.3:
-    dependencies:
-      glob: 7.2.3
-
   rimraf@6.1.3:
     dependencies:
       glob: 13.0.6
       package-json-from-dist: 1.0.1
-
-  run-async@2.4.1: {}
-
-  rxjs@6.6.7:
-    dependencies:
-      tslib: 1.14.1
 
   safe-buffer@5.2.1: {}
 
@@ -5531,8 +5143,6 @@ snapshots:
 
   secure-keys@1.0.0: {}
 
-  semver@5.7.2: {}
-
   semver@6.3.1: {}
 
   semver@7.8.5: {}
@@ -5543,15 +5153,9 @@ snapshots:
 
   set-blocking@2.0.0: {}
 
-  shebang-command@1.2.0:
-    dependencies:
-      shebang-regex: 1.0.0
-
   shebang-command@2.0.0:
     dependencies:
       shebang-regex: 3.0.0
-
-  shebang-regex@1.0.0: {}
 
   shebang-regex@3.0.0: {}
 
@@ -5602,16 +5206,6 @@ snapshots:
       '@sinonjs/samsam': 10.0.2
       diff: 9.0.0
 
-  slice-ansi@2.1.0:
-    dependencies:
-      ansi-styles: 3.2.1
-      astral-regex: 1.0.0
-      is-fullwidth-code-point: 2.0.0
-
-  snake-case@2.1.0:
-    dependencies:
-      no-case: 2.3.2
-
   source-map@0.6.1: {}
 
   spawn-wrap@3.0.0:
@@ -5652,17 +5246,6 @@ snapshots:
       safer-buffer: 2.1.2
       tweetnacl: 0.14.5
 
-  string-width@2.1.1:
-    dependencies:
-      is-fullwidth-code-point: 2.0.0
-      strip-ansi: 4.0.0
-
-  string-width@3.1.0:
-    dependencies:
-      emoji-regex: 7.0.3
-      is-fullwidth-code-point: 2.0.0
-      strip-ansi: 5.2.0
-
   string-width@4.2.3:
     dependencies:
       emoji-regex: 8.0.0
@@ -5680,14 +5263,6 @@ snapshots:
       safe-buffer: 5.2.1
     optional: true
 
-  strip-ansi@4.0.0:
-    dependencies:
-      ansi-regex: 3.0.1
-
-  strip-ansi@5.2.0:
-    dependencies:
-      ansi-regex: 4.1.1
-
   strip-ansi@6.0.1:
     dependencies:
       ansi-regex: 5.0.1
@@ -5698,13 +5273,10 @@ snapshots:
 
   strip-bom@4.0.0: {}
 
-  strip-json-comments@2.0.1: {}
+  strip-json-comments@2.0.1:
+    optional: true
 
   strip-json-comments@3.1.1: {}
-
-  supports-color@5.5.0:
-    dependencies:
-      has-flag: 3.0.0
 
   supports-color@7.2.0:
     dependencies:
@@ -5715,13 +5287,6 @@ snapshots:
       has-flag: 4.0.0
 
   supports-preserve-symlinks-flag@1.0.0: {}
-
-  table@5.4.6:
-    dependencies:
-      ajv: 6.15.0
-      lodash: 4.18.1
-      slice-ansi: 2.1.0
-      string-width: 3.1.0
 
   tar-fs@2.1.5:
     dependencies:
@@ -5757,10 +5322,6 @@ snapshots:
       glob: 13.0.6
       minimatch: 10.2.5
 
-  text-table@0.2.0: {}
-
-  through@2.3.8: {}
-
   tildify@2.0.0: {}
 
   tinyglobby@0.2.17:
@@ -5769,16 +5330,12 @@ snapshots:
       picomatch: 4.0.4
     optional: true
 
-  tmp@0.0.33:
-    dependencies:
-      os-tmpdir: 1.0.2
+  tinypool@2.1.0: {}
 
   tough-cookie@2.5.0:
     dependencies:
       psl: 1.15.0
       punycode: 2.3.1
-
-  tslib@1.14.1: {}
 
   tslib@2.8.1: {}
 
@@ -5788,15 +5345,9 @@ snapshots:
 
   tweetnacl@0.14.5: {}
 
-  type-check@0.3.2:
-    dependencies:
-      prelude-ls: 1.1.2
-
   type-detect@4.0.8: {}
 
   type-detect@4.1.0: {}
-
-  type-fest@0.21.3: {}
 
   type-fest@0.8.1: {}
 
@@ -5834,8 +5385,6 @@ snapshots:
 
   uuid@9.0.1: {}
 
-  v8-compile-cache@2.4.0: {}
-
   validator@7.2.0: {}
 
   verror@1.10.0:
@@ -5846,10 +5395,6 @@ snapshots:
 
   which-module@2.0.1: {}
 
-  which@1.3.1:
-    dependencies:
-      isexe: 2.0.0
-
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
@@ -5858,8 +5403,6 @@ snapshots:
     dependencies:
       isexe: 4.0.0
     optional: true
-
-  word-wrap@1.2.5: {}
 
   workerpool@9.3.4: {}
 
@@ -5881,7 +5424,8 @@ snapshots:
       string-width: 5.1.2
       strip-ansi: 7.2.0
 
-  wrappy@1.0.2: {}
+  wrappy@1.0.2:
+    optional: true
 
   write-file-atomic@3.0.3:
     dependencies:
@@ -5889,10 +5433,6 @@ snapshots:
       is-typedarray: 1.0.0
       signal-exit: 3.0.7
       typedarray-to-buffer: 3.1.5
-
-  write@1.0.3:
-    dependencies:
-      mkdirp: 0.5.6
 
   y18n@4.0.3: {}
 

--- a/scripts/ghost-consumer-smoke.js
+++ b/scripts/ghost-consumer-smoke.js
@@ -2,30 +2,38 @@
 
 const childProcess = require('child_process');
 const fs = require('fs');
-const {createRequire} = require('module');
+const { createRequire } = require('module');
 const os = require('os');
 const path = require('path');
 const compareVer = require('compare-ver');
 
 const repoRoot = path.resolve(__dirname, '..');
-const ghostPath = process.env.GHOST_CORE_PATH || process.argv[2] || path.join(repoRoot, '..', 'Ghost');
-const migratorBin = path.resolve(process.env.KNEX_MIGRATOR_BIN || path.join(repoRoot, 'bin', 'knex-migrator'));
-const migratorCwd = path.resolve(process.env.KNEX_MIGRATOR_CWD || (process.env.KNEX_MIGRATOR_BIN ? process.cwd() : repoRoot));
+const ghostPath =
+    process.env.GHOST_CORE_PATH || process.argv[2] || path.join(repoRoot, '..', 'Ghost');
+const migratorBin = path.resolve(
+    process.env.KNEX_MIGRATOR_BIN || path.join(repoRoot, 'bin', 'knex-migrator'),
+);
+const migratorCwd = path.resolve(
+    process.env.KNEX_MIGRATOR_CWD || (process.env.KNEX_MIGRATOR_BIN ? process.cwd() : repoRoot),
+);
 
 function resolveGhostCorePath(inputPath) {
     const resolvedPath = path.resolve(inputPath);
-    const candidates = [
-        resolvedPath,
-        path.join(resolvedPath, 'ghost', 'core')
-    ];
+    const candidates = [resolvedPath, path.join(resolvedPath, 'ghost', 'core')];
 
     const corePath = candidates.find((candidatePath) => {
-        return fs.existsSync(path.join(candidatePath, 'package.json'))
-            && fs.existsSync(path.join(candidatePath, 'MigratorConfig.js'));
+        return (
+            fs.existsSync(path.join(candidatePath, 'package.json')) &&
+            fs.existsSync(path.join(candidatePath, 'MigratorConfig.js'))
+        );
     });
 
     if (!corePath) {
-        fail('Ghost core package.json not found from ' + resolvedPath + '. Set GHOST_CORE_PATH to a Ghost repository or Ghost core checkout.');
+        fail(
+            'Ghost core package.json not found from ' +
+                resolvedPath +
+                '. Set GHOST_CORE_PATH to a Ghost repository or Ghost core checkout.',
+        );
     }
 
     return corePath;
@@ -55,7 +63,7 @@ function runStep(name, args, env) {
         cwd: migratorCwd,
         env: env,
         encoding: 'utf8',
-        stdio: ['ignore', 'pipe', 'pipe']
+        stdio: ['ignore', 'pipe', 'pipe'],
     });
 
     if (result.stdout) {
@@ -72,14 +80,15 @@ function runStep(name, args, env) {
 }
 
 function getGhostVersion() {
-    const result = childProcess.spawnSync(process.execPath, [
-        '-e',
-        'process.stdout.write(require("@tryghost/version").safe);'
-    ], {
-        cwd: ghostCorePath,
-        encoding: 'utf8',
-        stdio: ['ignore', 'pipe', 'pipe']
-    });
+    const result = childProcess.spawnSync(
+        process.execPath,
+        ['-e', 'process.stdout.write(require("@tryghost/version").safe);'],
+        {
+            cwd: ghostCorePath,
+            encoding: 'utf8',
+            stdio: ['ignore', 'pipe', 'pipe'],
+        },
+    );
 
     if (result.status !== 0) {
         if (result.stderr) {
@@ -94,11 +103,22 @@ function getGhostVersion() {
 
 function getGhostVersions() {
     const ghostVersion = getGhostVersion();
-    const versionsPath = path.join(ghostCorePath, 'core', 'server', 'data', 'migrations', 'versions');
+    const versionsPath = path.join(
+        ghostCorePath,
+        'core',
+        'server',
+        'data',
+        'migrations',
+        'versions',
+    );
 
-    const versions = sortVersions(fs.readdirSync(versionsPath).filter((entry) => {
-        return !entry.startsWith('.') && fs.statSync(path.join(versionsPath, entry)).isDirectory();
-    })).filter((version) => {
+    const versions = sortVersions(
+        fs.readdirSync(versionsPath).filter((entry) => {
+            return (
+                !entry.startsWith('.') && fs.statSync(path.join(versionsPath, entry)).isDirectory()
+            );
+        }),
+    ).filter((version) => {
         return compareVer.gt(version, ghostVersion) !== 1;
     });
 
@@ -112,13 +132,17 @@ function getGhostVersions() {
     return {
         ghostVersion,
         currentVersion,
-        previousVersion
+        previousVersion,
     };
 }
 
 function main() {
     if (!fs.existsSync(migratorBin)) {
-        fail('knex-migrator bin not found at ' + migratorBin + '. Set KNEX_MIGRATOR_BIN to the linked package bin.');
+        fail(
+            'knex-migrator bin not found at ' +
+                migratorBin +
+                '. Set KNEX_MIGRATOR_BIN to the linked package bin.',
+        );
     }
 
     requireFromGhost('knex');
@@ -128,12 +152,12 @@ function main() {
     const dbPath = path.join(tempPath, 'ghost-smoke.sqlite');
     const contentPath = path.join(tempPath, 'content');
 
-    fs.mkdirSync(path.join(contentPath, 'data'), {recursive: true});
+    fs.mkdirSync(path.join(contentPath, 'data'), { recursive: true });
 
     const env = Object.assign({}, process.env, {
         NODE_ENV: 'testing',
         database__connection__filename: dbPath,
-        paths__contentPath: contentPath
+        paths__contentPath: contentPath,
     });
 
     console.log('Ghost core: ' + ghostCorePath);
@@ -146,12 +170,20 @@ function main() {
     try {
         runStep('Ghost migrate --init', ['migrate', '--mgpath', ghostCorePath, '--init'], env);
         runStep('Ghost health after init', ['health', '--mgpath', ghostCorePath], env);
-        runStep('Ghost rollback to ' + versions.previousVersion, ['rollback', '--mgpath', ghostCorePath, '--force', '--v', versions.previousVersion], env);
-        runStep('Ghost migrate to ' + versions.currentVersion, ['migrate', '--mgpath', ghostCorePath, '--v', versions.currentVersion, '--force'], env);
+        runStep(
+            'Ghost rollback to ' + versions.previousVersion,
+            ['rollback', '--mgpath', ghostCorePath, '--force', '--v', versions.previousVersion],
+            env,
+        );
+        runStep(
+            'Ghost migrate to ' + versions.currentVersion,
+            ['migrate', '--mgpath', ghostCorePath, '--v', versions.currentVersion, '--force'],
+            env,
+        );
         runStep('Ghost health after rollback/migrate', ['health', '--mgpath', ghostCorePath], env);
     } finally {
         if (!process.env.KEEP_GHOST_SMOKE_DB) {
-            fs.rmSync(tempPath, {recursive: true, force: true});
+            fs.rmSync(tempPath, { recursive: true, force: true });
         } else {
             console.log('Kept smoke temp path: ' + tempPath);
         }

--- a/test/.eslintrc.js
+++ b/test/.eslintrc.js
@@ -1,9 +1,0 @@
-module.exports = {
-    plugins: ['ghost'],
-    extends: [
-        'plugin:ghost/test'
-    ],
-    rules: {
-        'no-unused-vars': 'off'
-    }
-};

--- a/test/assets/migrations_4/versions/1.1/4-select.js
+++ b/test/assets/migrations_4/versions/1.1/4-select.js
@@ -1,10 +1,9 @@
 module.exports.config = {
-    transaction: true
+    transaction: true,
 };
 
 module.exports.up = function doesNothing(options) {
-    return options.transacting.raw('SELECT * FROM users;')
-        .then(function () {
-            return options.transacting.raw('SELECT * FROM users;');
-        });
+    return options.transacting.raw('SELECT * FROM users;').then(function () {
+        return options.transacting.raw('SELECT * FROM users;');
+    });
 };

--- a/test/assets/migrations_5/versions/1.2/1-hey.js
+++ b/test/assets/migrations_5/versions/1.2/1-hey.js
@@ -7,5 +7,5 @@ module.exports.rollback = function rollback(options) {
 };
 
 module.exports.config = {
-    ddl: true
+    ddl: true,
 };

--- a/test/config/index.js
+++ b/test/config/index.js
@@ -18,7 +18,7 @@ _private.loadNconf = function loadNconf() {
      * env arguments
      */
     nconf.env({
-        separator: '__'
+        separator: '__',
     });
 
     nconf.file('custom-env', path.join(customConfigPath, 'config.' + env + '.json'));

--- a/test/functional/database_spec.js
+++ b/test/functional/database_spec.js
@@ -8,15 +8,16 @@ describe('Database', function () {
         dbConfig = {
             client: 'sqlite3',
             connection: {
-                filename: databaseFile
-            }
+                filename: databaseFile,
+            },
         };
 
     beforeEach(function (done) {
         this.timeout(10 * 1000);
         connection1 = database.connect(dbConfig);
 
-        connection1.raw('CREATE TABLE test (a Int);')
+        connection1
+            .raw('CREATE TABLE test (a Int);')
             .then(function () {
                 done();
             })
@@ -39,7 +40,8 @@ describe('Database', function () {
                 return done(err);
             }
 
-            connection2.raw('SELECT * from test;')
+            connection2
+                .raw('SELECT * from test;')
                 .then(function () {
                     done();
                 })
@@ -53,24 +55,27 @@ describe('Database', function () {
         const connection2 = database.connect({
             client: 'mysql',
             connection: {
-                host: 'unknown'
-            }
+                host: 'unknown',
+            },
         });
 
-        return database.ensureConnectionWorks(connection2).then(() => {
-            '1'.should.eql(1, 'Test should fail.');
-        }).catch((err) => {
-            (err instanceof errors.DatabaseError).should.be.true();
-            err.message.should.eql('Invalid database host.');
-        });
+        return database
+            .ensureConnectionWorks(connection2)
+            .then(() => {
+                '1'.should.eql(1, 'Test should fail.');
+            })
+            .catch((err) => {
+                (err instanceof errors.DatabaseError).should.be.true();
+                err.message.should.eql('Invalid database host.');
+            });
     });
 
     it('ensure test connection works', function () {
         const connection2 = database.connect({
             client: 'sqlite3',
             connection: {
-                filename: databaseFile
-            }
+                filename: databaseFile,
+            },
         });
 
         return database.ensureConnectionWorks(connection2);

--- a/test/functional/function_edge_cases_spec.js
+++ b/test/functional/function_edge_cases_spec.js
@@ -21,16 +21,16 @@ describe('Functional flow: Edge Cases', function () {
         testUtils.writeMigratorConfig({
             migratorConfigPath: migratorConfigPath,
             migrationPath: migrationPath,
-            currentVersion: '1.0'
+            currentVersion: '1.0',
         });
 
         knexMigrator = new KnexMigrator({
-            knexMigratorFilePath: path.join(__dirname, '..', 'assets')
+            knexMigratorFilePath: path.join(__dirname, '..', 'assets'),
         });
     });
 
     before(function () {
-        return knexMigrator.reset({force: true});
+        return knexMigrator.reset({ force: true });
     });
 
     before(function () {
@@ -61,7 +61,8 @@ describe('Functional flow: Edge Cases', function () {
     });
 
     it('run init, but process gets destroyed', function () {
-        return knexMigrator.init()
+        return knexMigrator
+            .init()
             .then(function () {
                 return connection('migrations');
             })

--- a/test/functional/functional_spec.js
+++ b/test/functional/functional_spec.js
@@ -16,7 +16,7 @@ _private.init = function init(knexMigrator, initMethod) {
     if (initMethod === 'default') {
         return knexMigrator.init();
     } else {
-        return knexMigrator.migrate({init: true});
+        return knexMigrator.migrate({ init: true });
     }
 };
 
@@ -91,16 +91,16 @@ _.each(['default', 'migrateInit'], function (initMethod) {
             testUtils.writeMigratorConfig({
                 migratorConfigPath: migratorConfigPath,
                 migrationPath: migrationPath,
-                currentVersion: '1.0'
+                currentVersion: '1.0',
             });
 
             knexMigrator = new KnexMigrator({
-                knexMigratorFilePath: path.join(__dirname, '..', 'assets')
+                knexMigratorFilePath: path.join(__dirname, '..', 'assets'),
             });
         });
 
         before(function () {
-            return knexMigrator.reset({force: true});
+            return knexMigrator.reset({ force: true });
         });
 
         before(function () {
@@ -175,7 +175,8 @@ _.each(['default', 'migrateInit'], function (initMethod) {
         });
 
         it('is database ok? --> no, because the db was never initialised', function () {
-            return knexMigrator.isDatabaseOK()
+            return knexMigrator
+                .isDatabaseOK()
                 .then(function () {
                     throw new Error('Database should be NOT ok!');
                 })
@@ -193,7 +194,8 @@ _.each(['default', 'migrateInit'], function (initMethod) {
         });
 
         it('init', function () {
-            return _private.init(knexMigrator, initMethod)
+            return _private
+                .init(knexMigrator, initMethod)
                 .then(function () {
                     return connection('users');
                 })
@@ -230,7 +232,8 @@ _.each(['default', 'migrateInit'], function (initMethod) {
         });
 
         it('call init again', function () {
-            return _private.init(knexMigrator, initMethod)
+            return _private
+                .init(knexMigrator, initMethod)
                 .then(function () {
                     return connection('users');
                 })
@@ -259,13 +262,13 @@ _.each(['default', 'migrateInit'], function (initMethod) {
             fs.mkdirSync(migrationsv12);
 
             let jsFile = testUtils.generateMigrationScript({
-                up: 'UPDATE users set name=\'Hausmann\';',
-                down: 'UPDATE users set name=\'LULULU\';'
+                up: "UPDATE users set name='Hausmann';",
+                down: "UPDATE users set name='LULULU';",
             });
 
             let jsFile1 = testUtils.generateMigrationScript({
-                up: 'UPDATE users set name=\'Kind\';',
-                down: 'UPDATE users set name=\'Hausmann\';'
+                up: "UPDATE users set name='Kind';",
+                down: "UPDATE users set name='Hausmann';",
             });
 
             fs.writeFileSync(migrationsv11File, jsFile);
@@ -277,7 +280,8 @@ _.each(['default', 'migrateInit'], function (initMethod) {
         });
 
         it('is database ok? --> no, 1.1 and 1.2 migrations are missing', function () {
-            return knexMigrator.isDatabaseOK()
+            return knexMigrator
+                .isDatabaseOK()
                 .then(function () {
                     throw new Error('database should be not ok');
                 })
@@ -289,7 +293,8 @@ _.each(['default', 'migrateInit'], function (initMethod) {
 
         it('migrate to 1.1 and 1.2', function () {
             // covers case that init completion is not executed (!)
-            return knexMigrator.migrate({init: true})
+            return knexMigrator
+                .migrate({ init: true })
                 .then(function () {
                     return connection('users');
                 })
@@ -329,7 +334,8 @@ _.each(['default', 'migrateInit'], function (initMethod) {
         });
 
         it('migrate 1.2 (--v)', function () {
-            return knexMigrator.migrate({version: '1.2'})
+            return knexMigrator
+                .migrate({ version: '1.2' })
                 .then(function () {
                     return connection('users');
                 })
@@ -372,13 +378,14 @@ _.each(['default', 'migrateInit'], function (initMethod) {
             fs.mkdirSync(migrationsv13);
 
             let jsFile = testUtils.generateMigrationScript({
-                up: 'DELETE FROM users where name=\'Kind\';',
-                down: 'INSERT INTO users (name) VALUES ("Kind");'
+                up: "DELETE FROM users where name='Kind';",
+                down: 'INSERT INTO users (name) VALUES ("Kind");',
             });
 
             fs.writeFileSync(migrationsv13File, jsFile);
 
-            return knexMigrator.migrate()
+            return knexMigrator
+                .migrate()
                 .then(function () {
                     return connection('users');
                 })
@@ -431,10 +438,11 @@ _.each(['default', 'migrateInit'], function (initMethod) {
                 fs.mkdirSync(migrationsv14);
 
                 let jsFile1 = testUtils.generateMigrationScript({
-                    up: 'SELECT * FROM users;'
+                    up: 'SELECT * FROM users;',
                 });
 
-                let jsFile2 = '' +
+                let jsFile2 =
+                    '' +
                     'module.exports.up = function scriptWillThrowError(options) {' +
                     'return Promise.reject(new Error("unexpected error"));' +
                     '};';
@@ -442,7 +450,8 @@ _.each(['default', 'migrateInit'], function (initMethod) {
                 fs.writeFileSync(migrationsv14File1, jsFile1);
                 fs.writeFileSync(migrationsv14File2, jsFile2);
 
-                return knexMigrator.migrate()
+                return knexMigrator
+                    .migrate()
                     .then(function () {
                         throw new Error('This test case should fail! Please check why!');
                     })
@@ -493,11 +502,10 @@ _.each(['default', 'migrateInit'], function (initMethod) {
                 fs.mkdirSync(migrationsv14);
 
                 let jsFile1 = testUtils.generateMigrationScript({
-                    up: 'SELECT * FROM users;'
+                    up: 'SELECT * FROM users;',
                 });
 
-                let jsFile2 = '' +
-                    'var Promise = require("lalalalala");';
+                let jsFile2 = '' + 'var Promise = require("lalalalala");';
 
                 fs.writeFileSync(migrationsv14File1, jsFile1);
                 fs.writeFileSync(migrationsv14File2, jsFile2);
@@ -513,7 +521,7 @@ _.each(['default', 'migrateInit'], function (initMethod) {
                     })
                     .catch(function (err) {
                         should.exist(err);
-                        err.message.should.startWith('Cannot find module \'lalalalala\'');
+                        err.message.should.startWith("Cannot find module 'lalalalala'");
 
                         return connection('users')
                             .then(function (values) {
@@ -555,18 +563,19 @@ _.each(['default', 'migrateInit'], function (initMethod) {
                 fs.rmdirSync(migrationsv14);
                 fs.mkdirSync(migrationsv14);
 
-                let jsFile1 = '' +
+                let jsFile1 =
+                    '' +
                     'module.exports.up = function success(options) {' +
                     'return Promise.resolve();' +
                     '};';
 
-                let jsFile2 = '' +
-                    'var x = y;';
+                let jsFile2 = '' + 'var x = y;';
 
                 fs.writeFileSync(migrationsv14File1, jsFile1);
                 fs.writeFileSync(migrationsv14File2, jsFile2);
 
-                return knexMigrator.migrate()
+                return knexMigrator
+                    .migrate()
                     .then(function () {
                         throw new Error('This test case should fail! Please check why!');
                     })
@@ -612,12 +621,14 @@ _.each(['default', 'migrateInit'], function (initMethod) {
                 fs.rmdirSync(migrationsv14);
                 fs.mkdirSync(migrationsv14);
 
-                let jsFile1 = '' +
+                let jsFile1 =
+                    '' +
                     'module.exports.up = function success(options) {' +
                     'return Promise.resolve();' +
                     '};';
 
-                let jsFile2 = '' +
+                let jsFile2 =
+                    '' +
                     'module.exports.up = function success(options) {' +
                     'return Promise.resolve();' +
                     '};';
@@ -625,7 +636,8 @@ _.each(['default', 'migrateInit'], function (initMethod) {
                 fs.writeFileSync(migrationsv14File1, jsFile1);
                 fs.writeFileSync(migrationsv14File2, jsFile2);
 
-                return knexMigrator.migrate()
+                return knexMigrator
+                    .migrate()
                     .then(function () {
                         return connection('users');
                     })
@@ -677,9 +689,7 @@ _.each(['default', 'migrateInit'], function (initMethod) {
 
                         removedEntry = values[7];
 
-                        return connection('migrations')
-                            .where('id', values[7].id)
-                            .delete();
+                        return connection('migrations').where('id', values[7].id).delete();
                     })
                     .then(function () {
                         return connection('migrations');
@@ -715,14 +725,16 @@ _.each(['default', 'migrateInit'], function (initMethod) {
             it('migrate to 1.5, but current version is 1.4 (no force)', function () {
                 fs.mkdirSync(migrationsv15);
 
-                let jsFile1 = '' +
+                let jsFile1 =
+                    '' +
                     'module.exports.up = function success(options) {' +
                     'return Promise.resolve();' +
                     '};';
 
                 fs.writeFileSync(migrationsv15File1, jsFile1);
 
-                return knexMigrator.migrate()
+                return knexMigrator
+                    .migrate()
                     .then(function () {
                         return connection('users');
                     })
@@ -760,7 +772,8 @@ _.each(['default', 'migrateInit'], function (initMethod) {
 
             it('migrate 1.5 (--v) and force', function () {
                 // current is 1.4
-                return knexMigrator.migrate({version: '1.5', force: true})
+                return knexMigrator
+                    .migrate({ version: '1.5', force: true })
                     .then(function () {
                         return connection('users');
                     })
@@ -804,14 +817,18 @@ _.each(['default', 'migrateInit'], function (initMethod) {
             knexMigrator.currentVersion = '1.4';
             if (DatabaseInfo.isSQLiteConfig(config.get('database'))) {
                 return connection.raw(`PRAGMA index_list('migrations_lock');`).then((indexes) => {
-                    indexes.filter(index => index.origin === 'pk').length.should.eql(1);
+                    indexes.filter((index) => index.origin === 'pk').length.should.eql(1);
                 });
             } else {
-                return connection.raw(`
+                return connection
+                    .raw(
+                        `
                 SELECT CONSTRAINT_NAME
                 FROM information_schema.TABLE_CONSTRAINTS
                 WHERE TABLE_NAME=:tableName
-                AND CONSTRAINT_TYPE='PRIMARY KEY'`, {tableName: 'migrations_lock'})
+                AND CONSTRAINT_TYPE='PRIMARY KEY'`,
+                        { tableName: 'migrations_lock' },
+                    )
                     .then(([rawConstraints]) => {
                         rawConstraints.length.should.eql(1);
                     });

--- a/test/functional/implicit_commits_spec.js
+++ b/test/functional/implicit_commits_spec.js
@@ -23,8 +23,7 @@ _private.assertTableMissingError = function assertTableMissingError(err) {
     }
 };
 
-let migratorConfigPath,
-    migrationPath;
+let migratorConfigPath, migrationPath;
 
 let knexMigrator, connection;
 
@@ -34,17 +33,23 @@ describe('Implicit Commits', function () {
     describe('knex-migrator init', function () {
         describe('fail #1', function () {
             before(function () {
-                migratorConfigPath = path.join(__dirname, '..', 'assets', 'migrations_1', 'MigratorConfig.js');
+                migratorConfigPath = path.join(
+                    __dirname,
+                    '..',
+                    'assets',
+                    'migrations_1',
+                    'MigratorConfig.js',
+                );
                 migrationPath = path.join(__dirname, '..', 'assets', 'migrations_1');
 
                 testUtils.writeMigratorConfig({
                     migratorConfigPath: migratorConfigPath,
                     migrationPath: migrationPath,
-                    currentVersion: '1.0'
+                    currentVersion: '1.0',
                 });
 
                 knexMigrator = new KnexMigrator({
-                    knexMigratorFilePath: migrationPath
+                    knexMigratorFilePath: migrationPath,
                 });
 
                 connection = testUtils.connect();
@@ -59,7 +64,8 @@ describe('Implicit Commits', function () {
             });
 
             it('expect full DML rollback', function () {
-                return knexMigrator.init()
+                return knexMigrator
+                    .init()
                     .then(function () {
                         throw new Error('init should fail');
                     })
@@ -80,17 +86,23 @@ describe('Implicit Commits', function () {
 
         describe('fail #2', function () {
             before(function () {
-                migratorConfigPath = path.join(__dirname, '..', 'assets', 'migrations_2', 'MigratorConfig.js');
+                migratorConfigPath = path.join(
+                    __dirname,
+                    '..',
+                    'assets',
+                    'migrations_2',
+                    'MigratorConfig.js',
+                );
                 migrationPath = path.join(__dirname, '..', 'assets', 'migrations_2');
 
                 testUtils.writeMigratorConfig({
                     migratorConfigPath: migratorConfigPath,
                     migrationPath: migrationPath,
-                    currentVersion: '1.0'
+                    currentVersion: '1.0',
                 });
 
                 knexMigrator = new KnexMigrator({
-                    knexMigratorFilePath: migrationPath
+                    knexMigratorFilePath: migrationPath,
                 });
 
                 connection = testUtils.connect();
@@ -105,7 +117,8 @@ describe('Implicit Commits', function () {
             });
 
             it('expect full DDL/DML rollback', function () {
-                return knexMigrator.init()
+                return knexMigrator
+                    .init()
                     .then(function () {
                         throw new Error('init should fail');
                     })
@@ -129,17 +142,23 @@ describe('Implicit Commits', function () {
 
         describe('success #1', function () {
             before(function () {
-                migratorConfigPath = path.join(__dirname, '..', 'assets', 'migrations_3', 'MigratorConfig.js');
+                migratorConfigPath = path.join(
+                    __dirname,
+                    '..',
+                    'assets',
+                    'migrations_3',
+                    'MigratorConfig.js',
+                );
                 migrationPath = path.join(__dirname, '..', 'assets', 'migrations_3');
 
                 testUtils.writeMigratorConfig({
                     migratorConfigPath: migratorConfigPath,
                     migrationPath: migrationPath,
-                    currentVersion: '1.0'
+                    currentVersion: '1.0',
                 });
 
                 knexMigrator = new KnexMigrator({
-                    knexMigratorFilePath: migrationPath
+                    knexMigratorFilePath: migrationPath,
                 });
 
                 connection = testUtils.connect();
@@ -154,7 +173,8 @@ describe('Implicit Commits', function () {
             });
 
             it('expect no rollback', function () {
-                return knexMigrator.init()
+                return knexMigrator
+                    .init()
                     .then(function () {
                         return connection('users');
                     })
@@ -173,17 +193,23 @@ describe('Implicit Commits', function () {
     describe('knex-migrator migrate', function () {
         describe('fail #1', function () {
             before(function () {
-                migratorConfigPath = path.join(__dirname, '..', 'assets', 'migrations_4', 'MigratorConfig.js');
+                migratorConfigPath = path.join(
+                    __dirname,
+                    '..',
+                    'assets',
+                    'migrations_4',
+                    'MigratorConfig.js',
+                );
                 migrationPath = path.join(__dirname, '..', 'assets', 'migrations_4');
 
                 testUtils.writeMigratorConfig({
                     migratorConfigPath: migratorConfigPath,
                     migrationPath: migrationPath,
-                    currentVersion: '1.0'
+                    currentVersion: '1.0',
                 });
 
                 knexMigrator = new KnexMigrator({
-                    knexMigratorFilePath: migrationPath
+                    knexMigratorFilePath: migrationPath,
                 });
 
                 connection = testUtils.connect();
@@ -198,16 +224,19 @@ describe('Implicit Commits', function () {
             });
 
             it('expect full DDL/DML rollback', function () {
-                return knexMigrator.init({skipInitCompletion: true})
+                return knexMigrator
+                    .init({ skipInitCompletion: true })
                     .then(function () {
                         return connection('users');
                     })
                     .then(function (values) {
                         // from init
                         values.length.should.eql(1);
-                        Object.prototype.hasOwnProperty.call(values[0], 'country').should.eql(false);
+                        Object.prototype.hasOwnProperty
+                            .call(values[0], 'country')
+                            .should.eql(false);
 
-                        return knexMigrator.migrate({force: true});
+                        return knexMigrator.migrate({ force: true });
                     })
                     .then(function () {
                         throw new Error('Expect error from migrate.');
@@ -234,24 +263,32 @@ describe('Implicit Commits', function () {
                         // from init
                         values.length.should.eql(1);
 
-                        Object.prototype.hasOwnProperty.call(values[0], 'country').should.eql(false);
+                        Object.prototype.hasOwnProperty
+                            .call(values[0], 'country')
+                            .should.eql(false);
                     });
             });
         });
 
         describe('success #1', function () {
             before(function () {
-                migratorConfigPath = path.join(__dirname, '..', 'assets', 'migrations_5', 'MigratorConfig.js');
+                migratorConfigPath = path.join(
+                    __dirname,
+                    '..',
+                    'assets',
+                    'migrations_5',
+                    'MigratorConfig.js',
+                );
                 migrationPath = path.join(__dirname, '..', 'assets', 'migrations_5');
 
                 testUtils.writeMigratorConfig({
                     migratorConfigPath: migratorConfigPath,
                     migrationPath: migrationPath,
-                    currentVersion: '1.0'
+                    currentVersion: '1.0',
                 });
 
                 knexMigrator = new KnexMigrator({
-                    knexMigratorFilePath: migrationPath
+                    knexMigratorFilePath: migrationPath,
                 });
 
                 connection = testUtils.connect();
@@ -266,9 +303,10 @@ describe('Implicit Commits', function () {
             });
 
             it('expect no rollback', function () {
-                return knexMigrator.init({skipInitCompletion: true})
+                return knexMigrator
+                    .init({ skipInitCompletion: true })
                     .then(function () {
-                        return knexMigrator.migrate({force: true});
+                        return knexMigrator.migrate({ force: true });
                     })
                     .then(function () {
                         return connection('users');

--- a/test/functional/rollback_1_spec.js
+++ b/test/functional/rollback_1_spec.js
@@ -13,7 +13,15 @@ describe('knex-migrator rollback (default)', function () {
         migratorConfigPath = path.join(__dirname, '..', 'assets', 'MigratorConfig.js'),
         versionsFolder = path.join(__dirname, '..', 'assets', 'migrations_6', 'versions'),
         migration121 = path.join(__dirname, '..', 'assets', 'migrations_6', 'versions', '1.21'),
-        migration121File = path.join(__dirname, '..', 'assets', 'migrations_6', 'versions', '1.21', '1-test.js'),
+        migration121File = path.join(
+            __dirname,
+            '..',
+            'assets',
+            'migrations_6',
+            'versions',
+            '1.21',
+            '1-test.js',
+        ),
         connection;
 
     before(function () {
@@ -32,11 +40,11 @@ describe('knex-migrator rollback (default)', function () {
         testUtils.writeMigratorConfig({
             migratorConfigPath: migratorConfigPath,
             migrationPath: migrationPath,
-            currentVersion: '1.20'
+            currentVersion: '1.20',
         });
 
         knexMigrator = new KnexMigrator({
-            knexMigratorFilePath: path.join(__dirname, '..', 'assets')
+            knexMigratorFilePath: path.join(__dirname, '..', 'assets'),
         });
     });
 
@@ -92,8 +100,8 @@ describe('knex-migrator rollback (default)', function () {
         fs.mkdirSync(migration121);
 
         let jsFile = testUtils.generateMigrationScript({
-            up: 'UPDATE users set name=\'Kind\';',
-            down: 'UPDATE users set name=\'Hausmann\';'
+            up: "UPDATE users set name='Kind';",
+            down: "UPDATE users set name='Hausmann';",
         });
 
         fs.writeFileSync(migration121File, jsFile);
@@ -102,28 +110,31 @@ describe('knex-migrator rollback (default)', function () {
     });
 
     it('knex-migrator rollback', function () {
-        return knexMigrator.rollback({force: true});
+        return knexMigrator.rollback({ force: true });
     });
 
     it('knex-migrator health', function () {
-        return knexMigrator.isDatabaseOK()
+        return knexMigrator
+            .isDatabaseOK()
             .then(function () {
                 'Database should not be okay'.should.eql(false);
             })
             .catch(function (err) {
-                err.message.should.eql('Migrations are missing. Please run `pnpm knex-migrator migrate`.');
+                err.message.should.eql(
+                    'Migrations are missing. Please run `pnpm knex-migrator migrate`.',
+                );
             });
     });
 
     it('db check', function () {
-        return connection('migrations')
-            .then(function (migrations) {
-                migrations.length.should.eql(2);
-            });
+        return connection('migrations').then(function (migrations) {
+            migrations.length.should.eql(2);
+        });
     });
 
     it('knex-migrator rollback', function () {
-        return knexMigrator.rollback({force: true})
+        return knexMigrator
+            .rollback({ force: true })
             .then(function () {
                 'No rollback expected.'.should.eql(false);
             })

--- a/test/functional/rollback_2_spec.js
+++ b/test/functional/rollback_2_spec.js
@@ -14,7 +14,15 @@ describe('knex-migrator rollback (force)', function () {
         migratorConfigPath = path.join(__dirname, '..', 'assets', 'MigratorConfig.js'),
         versionsFolder = path.join(__dirname, '..', 'assets', 'migrations_6', 'versions'),
         migration121 = path.join(__dirname, '..', 'assets', 'migrations_6', 'versions', '1.21'),
-        migration121File = path.join(__dirname, '..', 'assets', 'migrations_6', 'versions', '1.21', '1-test.js'),
+        migration121File = path.join(
+            __dirname,
+            '..',
+            'assets',
+            'migrations_6',
+            'versions',
+            '1.21',
+            '1-test.js',
+        ),
         connection;
 
     before(function () {
@@ -33,11 +41,11 @@ describe('knex-migrator rollback (force)', function () {
         testUtils.writeMigratorConfig({
             migratorConfigPath: migratorConfigPath,
             migrationPath: migrationPath,
-            currentVersion: '1.20'
+            currentVersion: '1.20',
         });
 
         knexMigrator = new KnexMigrator({
-            knexMigratorFilePath: path.join(__dirname, '..', 'assets')
+            knexMigratorFilePath: path.join(__dirname, '..', 'assets'),
         });
     });
 
@@ -93,19 +101,19 @@ describe('knex-migrator rollback (force)', function () {
         fs.mkdirSync(migration121);
 
         let jsFile = testUtils.generateMigrationScript({
-            up: 'UPDATE users set name=\'Kind\';',
-            down: 'UPDATE users set name=\'Hausmann\';'
+            up: "UPDATE users set name='Kind';",
+            down: "UPDATE users set name='Hausmann';",
         });
 
         fs.writeFileSync(migration121File, jsFile);
 
         // we have to force, because we are still on 1.20
-        return knexMigrator.migrate({force: true});
+        return knexMigrator.migrate({ force: true });
     });
 
     // It rolls back all versions on the current version (in the migration table)
     it('knex-migrator rollback', function () {
-        return knexMigrator.rollback({force: true});
+        return knexMigrator.rollback({ force: true });
     });
 
     // Shows only a warning that 1.21 is available
@@ -114,9 +122,8 @@ describe('knex-migrator rollback (force)', function () {
     });
 
     it('db check', function () {
-        return connection('migrations')
-            .then(function (migrations) {
-                migrations.length.should.eql(2);
-            });
+        return connection('migrations').then(function (migrations) {
+            migrations.length.should.eql(2);
+        });
     });
 });

--- a/test/functional/rollback_3_spec.js
+++ b/test/functional/rollback_3_spec.js
@@ -17,11 +17,11 @@ describe('knex-migrator rollback (on init, auto-rollback)', function () {
         testUtils.writeMigratorConfig({
             migratorConfigPath: migratorConfigPath,
             migrationPath: migrationPath,
-            currentVersion: '1.20'
+            currentVersion: '1.20',
         });
 
         knexMigrator = new KnexMigrator({
-            knexMigratorFilePath: path.join(__dirname, '..', 'assets')
+            knexMigratorFilePath: path.join(__dirname, '..', 'assets'),
         });
     });
 
@@ -57,17 +57,21 @@ describe('knex-migrator rollback (on init, auto-rollback)', function () {
     });
 
     it('knex-migrator init', function () {
-        return knexMigrator.init()
+        return knexMigrator
+            .init()
             .then(function () {
                 'Should fail'.should.eql(false);
             })
             .catch(function (err) {
-                err.help.should.eql('Error occurred while executing the following migration: 2-seed.js');
+                err.help.should.eql(
+                    'Error occurred while executing the following migration: 2-seed.js',
+                );
             });
     });
 
     it('knex-migrator health', function () {
-        return knexMigrator.isDatabaseOK()
+        return knexMigrator
+            .isDatabaseOK()
             .then(function () {
                 'Should fail'.should.eql(false);
             })
@@ -77,9 +81,8 @@ describe('knex-migrator rollback (on init, auto-rollback)', function () {
     });
 
     it('db check', function () {
-        return connection('migrations')
-            .then(function (migrations) {
-                migrations.length.should.eql(0);
-            });
+        return connection('migrations').then(function (migrations) {
+            migrations.length.should.eql(0);
+        });
     });
 });

--- a/test/functional/rollback_4_spec.js
+++ b/test/functional/rollback_4_spec.js
@@ -25,11 +25,11 @@ describe('knex-migrator rollback (to specific version)', function () {
         testUtils.writeMigratorConfig({
             migratorConfigPath: migratorConfigPath,
             migrationPath: migrationPath,
-            currentVersion: '1.2'
+            currentVersion: '1.2',
         });
 
         knexMigrator = new KnexMigrator({
-            knexMigratorFilePath: path.join(__dirname, '..', 'assets')
+            knexMigratorFilePath: path.join(__dirname, '..', 'assets'),
         });
     });
 
@@ -69,7 +69,8 @@ describe('knex-migrator rollback (to specific version)', function () {
     });
 
     it('knex-migrator init', function () {
-        return knexMigrator.init()
+        return knexMigrator
+            .init()
             .then(() => {
                 return connection('migrations');
             })
@@ -82,30 +83,36 @@ describe('knex-migrator rollback (to specific version)', function () {
     });
 
     it('add', function () {
-        migrations.push({
-            folder: versionsFolder + '/1.3',
-            file: '1-test.js'
-        }, {
-            folder: versionsFolder + '/1.4',
-            file: '1-test.js'
-        }, {
-            folder: versionsFolder + '/1.6',
-            file: '1-test.js'
-        }, {
-            folder: versionsFolder + '/1.11',
-            file: '1-test.js'
-        }, {
-            folder: versionsFolder + '/1.20',
-            file: '1-test.js'
-        });
+        migrations.push(
+            {
+                folder: versionsFolder + '/1.3',
+                file: '1-test.js',
+            },
+            {
+                folder: versionsFolder + '/1.4',
+                file: '1-test.js',
+            },
+            {
+                folder: versionsFolder + '/1.6',
+                file: '1-test.js',
+            },
+            {
+                folder: versionsFolder + '/1.11',
+                file: '1-test.js',
+            },
+            {
+                folder: versionsFolder + '/1.20',
+                file: '1-test.js',
+            },
+        );
 
         fs.mkdirSync(versionsFolder);
         migrations.forEach((migration) => {
             fs.mkdirSync(migration.folder);
 
             let jsFile = testUtils.generateMigrationScript({
-                up: 'UPDATE users set name=\'Kind\';',
-                down: 'UPDATE users set name=\'Hausmann\';'
+                up: "UPDATE users set name='Kind';",
+                down: "UPDATE users set name='Hausmann';",
             });
 
             fs.writeFileSync(migration.folder + '/' + migration.file, jsFile);
@@ -117,7 +124,8 @@ describe('knex-migrator rollback (to specific version)', function () {
     });
 
     it('knex-migrator migrate', function () {
-        return knexMigrator.migrate()
+        return knexMigrator
+            .migrate()
             .then(() => {
                 return connection('migrations');
             })
@@ -131,7 +139,8 @@ describe('knex-migrator rollback (to specific version)', function () {
     });
 
     it('knex-migrator migrate', function () {
-        return knexMigrator.migrate()
+        return knexMigrator
+            .migrate()
             .then(() => {
                 return connection('migrations');
             })
@@ -145,7 +154,8 @@ describe('knex-migrator rollback (to specific version)', function () {
     });
 
     it('knex-migrator migrate', function () {
-        return knexMigrator.migrate()
+        return knexMigrator
+            .migrate()
             .then(() => {
                 return connection('migrations');
             })
@@ -159,7 +169,8 @@ describe('knex-migrator rollback (to specific version)', function () {
     });
 
     it('knex-migrator migrate', function () {
-        return knexMigrator.migrate()
+        return knexMigrator
+            .migrate()
             .then(() => {
                 return connection('migrations');
             })
@@ -169,7 +180,8 @@ describe('knex-migrator rollback (to specific version)', function () {
     });
 
     it('knex-migrator rollback', function () {
-        return knexMigrator.rollback({force: true, version: '1.11.3'})
+        return knexMigrator
+            .rollback({ force: true, version: '1.11.3' })
             .then(() => {
                 return connection('migrations');
             })
@@ -180,7 +192,8 @@ describe('knex-migrator rollback (to specific version)', function () {
     });
 
     it('knex-migrator health', function () {
-        return knexMigrator.isDatabaseOK()
+        return knexMigrator
+            .isDatabaseOK()
             .then(() => {
                 '1'.should.eql(1);
             })
@@ -193,7 +206,8 @@ describe('knex-migrator rollback (to specific version)', function () {
     });
 
     it('knex-migrator rollback', function () {
-        return knexMigrator.rollback({force: true, version: '1.2'})
+        return knexMigrator
+            .rollback({ force: true, version: '1.2' })
             .then(() => {
                 return connection('migrations');
             })

--- a/test/unit/_rollback_spec.js
+++ b/test/unit/_rollback_spec.js
@@ -13,37 +13,39 @@ describe('Unit: _rollback', function () {
             knexMigratorConfig: {
                 database: {},
                 migrationPath: 'location',
-                currentVersion: '1.9'
-            }
+                currentVersion: '1.9',
+            },
         });
 
         knexMigrator.connection = sinon.stub().returns({
             where: sinon.stub().returns({
-                delete: sinon.stub()
-            })
+                delete: sinon.stub(),
+            }),
         });
 
         const tasks = [
             {
                 up: sinon.stub(),
                 down: sinon.stub().resolves(),
-                name: '1-something'
+                name: '1-something',
             },
             {
                 up: sinon.stub(),
                 down: sinon.stub().resolves(),
-                name: '2-something'
-            }
+                name: '2-something',
+            },
         ];
 
         sinon.stub(utils, 'readTasks').returns(tasks);
 
-        return knexMigrator._rollback({
-            version: '1.10'
-        }).then(function () {
-            tasks[0].down.called.should.eql(true);
-            tasks[1].down.called.should.eql(true);
-        });
+        return knexMigrator
+            ._rollback({
+                version: '1.10',
+            })
+            .then(function () {
+                tasks[0].down.called.should.eql(true);
+                tasks[1].down.called.should.eql(true);
+            });
     });
 
     it('rollback caused by an error during migration', function () {
@@ -51,38 +53,40 @@ describe('Unit: _rollback', function () {
             knexMigratorConfig: {
                 database: {},
                 migrationPath: 'location',
-                currentVersion: '1.9'
-            }
+                currentVersion: '1.9',
+            },
         });
 
         knexMigrator.connection = sinon.stub().returns({
             where: sinon.stub().returns({
-                delete: sinon.stub()
-            })
+                delete: sinon.stub(),
+            }),
         });
 
         const tasks = [
             {
                 up: sinon.stub(),
                 down: sinon.stub().resolves(),
-                name: '1-something'
+                name: '1-something',
             },
             {
                 up: sinon.stub(),
                 down: sinon.stub().resolves(),
-                name: '2-something'
-            }
+                name: '2-something',
+            },
         ];
 
         sinon.stub(utils, 'readTasks').returns(tasks);
 
-        return knexMigrator._rollback({
-            version: '1.10',
-            task: tasks[0]
-        }).then(function () {
-            tasks[0].down.called.should.eql(true);
-            tasks[1].down.called.should.eql(false);
-        });
+        return knexMigrator
+            ._rollback({
+                version: '1.10',
+                task: tasks[0],
+            })
+            .then(function () {
+                tasks[0].down.called.should.eql(true);
+                tasks[1].down.called.should.eql(false);
+            });
     });
 
     it('rollback caused by an error during migration', function () {
@@ -90,14 +94,14 @@ describe('Unit: _rollback', function () {
             knexMigratorConfig: {
                 database: {},
                 migrationPath: 'location',
-                currentVersion: '1.9'
-            }
+                currentVersion: '1.9',
+            },
         });
 
         knexMigrator.connection = sinon.stub().returns({
             where: sinon.stub().returns({
-                delete: sinon.stub()
-            })
+                delete: sinon.stub(),
+            }),
         });
 
         const tasks = [
@@ -106,25 +110,27 @@ describe('Unit: _rollback', function () {
                 down: sinon.stub().resolves(),
                 name: '1-something',
                 config: {
-                    transaction: true
-                }
+                    transaction: true,
+                },
             },
             {
                 up: sinon.stub(),
                 down: sinon.stub().resolves(),
-                name: '2-something'
-            }
+                name: '2-something',
+            },
         ];
 
         sinon.stub(utils, 'readTasks').returns(tasks);
 
-        return knexMigrator._rollback({
-            version: '1.10',
-            task: tasks[0]
-        }).then(function () {
-            tasks[0].down.called.should.eql(false);
-            tasks[1].down.called.should.eql(false);
-        });
+        return knexMigrator
+            ._rollback({
+                version: '1.10',
+                task: tasks[0],
+            })
+            .then(function () {
+                tasks[0].down.called.should.eql(false);
+                tasks[1].down.called.should.eql(false);
+            });
     });
 
     it('rollback caused by an error during migration', function () {
@@ -132,50 +138,52 @@ describe('Unit: _rollback', function () {
             knexMigratorConfig: {
                 database: {},
                 migrationPath: 'location',
-                currentVersion: '1.9'
-            }
+                currentVersion: '1.9',
+            },
         });
 
         knexMigrator.connection = sinon.stub().returns({
             where: sinon.stub().returns({
-                delete: sinon.stub()
-            })
+                delete: sinon.stub(),
+            }),
         });
 
         const tasks = [
             {
                 up: sinon.stub(),
                 down: sinon.stub().resolves(),
-                name: '1-something'
+                name: '1-something',
             },
             {
                 up: sinon.stub(),
                 down: sinon.stub().resolves(),
-                name: '2-something'
+                name: '2-something',
             },
             {
                 up: sinon.stub(),
                 down: sinon.stub().resolves(),
-                name: '3-something'
+                name: '3-something',
             },
             {
                 up: sinon.stub(),
                 down: sinon.stub().resolves(),
-                name: '4-something'
-            }
+                name: '4-something',
+            },
         ];
 
         sinon.stub(utils, 'readTasks').returns(tasks);
 
-        return knexMigrator._rollback({
-            version: '1.10',
-            task: tasks[2]
-        }).then(function () {
-            tasks[0].down.called.should.eql(true);
-            tasks[1].down.called.should.eql(true);
-            tasks[2].down.called.should.eql(true);
-            tasks[3].down.called.should.eql(false);
-        });
+        return knexMigrator
+            ._rollback({
+                version: '1.10',
+                task: tasks[2],
+            })
+            .then(function () {
+                tasks[0].down.called.should.eql(true);
+                tasks[1].down.called.should.eql(true);
+                tasks[2].down.called.should.eql(true);
+                tasks[3].down.called.should.eql(false);
+            });
     });
 
     it('aborts with irreversible migrations in manual rollback', function () {
@@ -183,48 +191,51 @@ describe('Unit: _rollback', function () {
             knexMigratorConfig: {
                 database: {},
                 migrationPath: 'location',
-                currentVersion: '3.0'
-            }
+                currentVersion: '3.0',
+            },
         });
 
         knexMigrator.connection = sinon.stub().returns({
             where: sinon.stub().returns({
-                delete: sinon.stub()
-            })
+                delete: sinon.stub(),
+            }),
         });
 
         const tasks = [
             {
                 up: sinon.stub(),
                 down: sinon.stub().resolves(),
-                name: '1-something'
+                name: '1-something',
             },
             {
-                config: {irreversible: true},
+                config: { irreversible: true },
                 up: sinon.stub(),
                 down: sinon.stub().resolves(),
-                name: '2-something'
+                name: '2-something',
             },
             {
                 up: sinon.stub(),
                 down: sinon.stub().resolves(),
-                name: '3-something'
-            }
+                name: '3-something',
+            },
         ];
 
         sinon.stub(utils, 'readTasks').returns(tasks);
 
-        return knexMigrator._rollback({
-            version: '2.31'
-        }).then(function () {
-            true.should.eql(false);
-        }).catch((err) => {
-            should.exist(err);
-            err.errorType.should.eql('IrreversibleMigrationError');
-            tasks[0].down.called.should.eql(false);
-            tasks[1].down.called.should.eql(false);
-            tasks[2].down.called.should.eql(false);
-        });
+        return knexMigrator
+            ._rollback({
+                version: '2.31',
+            })
+            .then(function () {
+                true.should.eql(false);
+            })
+            .catch((err) => {
+                should.exist(err);
+                err.errorType.should.eql('IrreversibleMigrationError');
+                tasks[0].down.called.should.eql(false);
+                tasks[1].down.called.should.eql(false);
+                tasks[2].down.called.should.eql(false);
+            });
     });
 
     it('aborts with irreversible migrations in automatical failure rollback', function () {
@@ -232,49 +243,52 @@ describe('Unit: _rollback', function () {
             knexMigratorConfig: {
                 database: {},
                 migrationPath: 'location',
-                currentVersion: '3.0'
-            }
+                currentVersion: '3.0',
+            },
         });
 
         knexMigrator.connection = sinon.stub().returns({
             where: sinon.stub().returns({
-                delete: sinon.stub()
-            })
+                delete: sinon.stub(),
+            }),
         });
 
         const tasks = [
             {
                 up: sinon.stub(),
                 down: sinon.stub().resolves(),
-                name: '1-something'
+                name: '1-something',
             },
             {
-                config: {irreversible: true},
+                config: { irreversible: true },
                 up: sinon.stub(),
                 down: sinon.stub().resolves(),
-                name: '2-something'
+                name: '2-something',
             },
             {
                 up: sinon.stub(),
                 down: sinon.stub().resolves(),
-                name: '3-something'
-            }
+                name: '3-something',
+            },
         ];
 
         sinon.stub(utils, 'readTasks').returns(tasks);
 
-        return knexMigrator._rollback({
-            version: '2.31',
-            task: tasks[2]
-        }).then(function () {
-            true.should.eql(false);
-        }).catch((err) => {
-            should.exist(err);
-            err.errorType.should.eql('IrreversibleMigrationError');
-            tasks[0].down.called.should.eql(false);
-            tasks[1].down.called.should.eql(false);
-            tasks[2].down.called.should.eql(false);
-        });
+        return knexMigrator
+            ._rollback({
+                version: '2.31',
+                task: tasks[2],
+            })
+            .then(function () {
+                true.should.eql(false);
+            })
+            .catch((err) => {
+                should.exist(err);
+                err.errorType.should.eql('IrreversibleMigrationError');
+                tasks[0].down.called.should.eql(false);
+                tasks[1].down.called.should.eql(false);
+                tasks[2].down.called.should.eql(false);
+            });
     });
 
     it('skips requested rollback tasks', function () {
@@ -282,34 +296,36 @@ describe('Unit: _rollback', function () {
             knexMigratorConfig: {
                 database: {},
                 migrationPath: 'location',
-                currentVersion: '1.9'
-            }
+                currentVersion: '1.9',
+            },
         });
 
         knexMigrator.connection = sinon.stub().returns({
             where: sinon.stub().returns({
-                delete: sinon.stub().resolves()
-            })
+                delete: sinon.stub().resolves(),
+            }),
         });
 
         const tasks = [
             {
                 up: sinon.stub(),
                 down: sinon.stub().resolves(),
-                name: '1-something'
-            }
+                name: '1-something',
+            },
         ];
 
         sinon.stub(utils, 'readTasks').returns(tasks);
 
-        return knexMigrator._rollback({
-            version: '1.10',
-            skippedTasks: {
-                '1.10': ['1-something']
-            }
-        }).then(function () {
-            tasks[0].down.called.should.eql(false);
-        });
+        return knexMigrator
+            ._rollback({
+                version: '1.10',
+                skippedTasks: {
+                    '1.10': ['1-something'],
+                },
+            })
+            .then(function () {
+                tasks[0].down.called.should.eql(false);
+            });
     });
 
     it('limits rollback to selected tasks', function () {
@@ -317,32 +333,34 @@ describe('Unit: _rollback', function () {
             knexMigratorConfig: {
                 database: {},
                 migrationPath: 'location',
-                currentVersion: '1.9'
-            }
+                currentVersion: '1.9',
+            },
         });
 
         knexMigrator.connection = sinon.stub().returns({
             where: sinon.stub().returns({
-                delete: sinon.stub().resolves()
-            })
+                delete: sinon.stub().resolves(),
+            }),
         });
 
         const tasks = [
             {
                 up: sinon.stub(),
                 down: sinon.stub().resolves(),
-                name: '1-something'
-            }
+                name: '1-something',
+            },
         ];
 
         sinon.stub(utils, 'readTasks').returns(tasks);
 
-        return knexMigrator._rollback({
-            version: '1.10',
-            onlyTasks: ['2-something']
-        }).then(function () {
-            tasks[0].down.called.should.eql(false);
-        });
+        return knexMigrator
+            ._rollback({
+                version: '1.10',
+                onlyTasks: ['2-something'],
+            })
+            .then(function () {
+                tasks[0].down.called.should.eql(false);
+            });
     });
 
     it('rolls back transaction-enabled tasks inside a transaction', function () {
@@ -350,35 +368,39 @@ describe('Unit: _rollback', function () {
             knexMigratorConfig: {
                 database: {},
                 migrationPath: 'location',
-                currentVersion: '1.9'
-            }
+                currentVersion: '1.9',
+            },
         });
 
         knexMigrator.connection = sinon.stub().returns({
             where: sinon.stub().returns({
-                delete: sinon.stub().resolves()
-            })
+                delete: sinon.stub().resolves(),
+            }),
         });
 
         const txn = {};
         const task = {
             config: {
-                transaction: true
+                transaction: true,
             },
             up: sinon.stub(),
             down: sinon.stub().resolves(),
-            name: '1-something'
+            name: '1-something',
         };
 
         sinon.stub(utils, 'readTasks').returns([task]);
-        sinon.stub(require('../../lib/database'), 'createTransaction').callsFake(function (connection, callback) {
-            return callback(txn);
-        });
+        sinon
+            .stub(require('../../lib/database'), 'createTransaction')
+            .callsFake(function (connection, callback) {
+                return callback(txn);
+            });
 
-        return knexMigrator._rollback({
-            version: '1.10'
-        }).then(function () {
-            task.down.calledWith({transacting: txn}).should.eql(true);
-        });
+        return knexMigrator
+            ._rollback({
+                version: '1.10',
+            })
+            .then(function () {
+                task.down.calledWith({ transacting: txn }).should.eql(true);
+            });
     });
 });

--- a/test/unit/database_spec.js
+++ b/test/unit/database_spec.js
@@ -17,8 +17,8 @@ describe('Database', function () {
             const connection = database.connect({
                 client: 'mysql',
                 connection: {
-                    filename: 'unused.db'
-                }
+                    filename: 'unused.db',
+                },
             });
 
             connection.client.config.client.should.eql('mysql2');
@@ -34,9 +34,9 @@ describe('Database', function () {
             const connection = database.connect({
                 client: 'sqlite3',
                 connection: {
-                    filename: ':memory:'
+                    filename: ':memory:',
                 },
-                useNullAsDefault: true
+                useNullAsDefault: true,
             });
 
             connection.client.config.useNullAsDefault.should.eql(true);
@@ -45,57 +45,73 @@ describe('Database', function () {
         });
 
         it('prefers a project-local knex module when a project path is provided', function () {
-            const projectPath = fs.mkdtempSync(path.join(os.tmpdir(), 'knex-migrator-project-knex-'));
+            const projectPath = fs.mkdtempSync(
+                path.join(os.tmpdir(), 'knex-migrator-project-knex-'),
+            );
             const knexPath = path.join(projectPath, 'node_modules', 'knex');
 
-            fs.mkdirSync(knexPath, {recursive: true});
-            fs.writeFileSync(path.join(knexPath, 'index.js'), [
-                'module.exports = function knex(options) {',
-                '  return {',
-                '    client: {config: options},',
-                '    loadedFromProject: true',
-                '  };',
-                '};',
-                ''
-            ].join('\n'));
+            fs.mkdirSync(knexPath, { recursive: true });
+            fs.writeFileSync(
+                path.join(knexPath, 'index.js'),
+                [
+                    'module.exports = function knex(options) {',
+                    '  return {',
+                    '    client: {config: options},',
+                    '    loadedFromProject: true',
+                    '  };',
+                    '};',
+                    '',
+                ].join('\n'),
+            );
 
             try {
-                const connection = database.connect({
-                    client: 'sqlite3',
-                    connection: {
-                        filename: ':memory:'
-                    }
-                }, {
-                    knexModulePath: projectPath
-                });
+                const connection = database.connect(
+                    {
+                        client: 'sqlite3',
+                        connection: {
+                            filename: ':memory:',
+                        },
+                    },
+                    {
+                        knexModulePath: projectPath,
+                    },
+                );
 
                 connection.loadedFromProject.should.eql(true);
                 connection.client.config.client.should.eql('sqlite3');
             } finally {
-                fs.rmSync(projectPath, {recursive: true, force: true});
+                fs.rmSync(projectPath, { recursive: true, force: true });
             }
         });
 
         it('throws project-local knex load errors', function () {
-            const projectPath = fs.mkdtempSync(path.join(os.tmpdir(), 'knex-migrator-broken-project-knex-'));
+            const projectPath = fs.mkdtempSync(
+                path.join(os.tmpdir(), 'knex-migrator-broken-project-knex-'),
+            );
             const knexPath = path.join(projectPath, 'node_modules', 'knex');
 
-            fs.mkdirSync(knexPath, {recursive: true});
-            fs.writeFileSync(path.join(knexPath, 'index.js'), 'throw new Error("broken project knex");\n');
+            fs.mkdirSync(knexPath, { recursive: true });
+            fs.writeFileSync(
+                path.join(knexPath, 'index.js'),
+                'throw new Error("broken project knex");\n',
+            );
 
             try {
                 (function () {
-                    database.connect({
-                        client: 'sqlite3',
-                        connection: {
-                            filename: ':memory:'
-                        }
-                    }, {
-                        knexModulePath: projectPath
-                    });
+                    database.connect(
+                        {
+                            client: 'sqlite3',
+                            connection: {
+                                filename: ':memory:',
+                            },
+                        },
+                        {
+                            knexModulePath: projectPath,
+                        },
+                    );
                 }).should.throw('broken project knex');
             } finally {
-                fs.rmSync(projectPath, {recursive: true, force: true});
+                fs.rmSync(projectPath, { recursive: true, force: true });
             }
         });
     });
@@ -105,27 +121,33 @@ describe('Database', function () {
             const err = new Error('temporary lookup failure');
             err.code = 'EAI_AGAIN';
 
-            return database.ensureConnectionWorks({
-                raw: sinon.stub().rejects(err)
-            }).then(function () {
-                true.should.eql(false);
-            }).catch(function (wrappedErr) {
-                wrappedErr.should.be.instanceof(errors.DatabaseError);
-                wrappedErr.message.should.eql('Invalid database host.');
-                wrappedErr.help.should.eql('Please double check your database config.');
-            });
+            return database
+                .ensureConnectionWorks({
+                    raw: sinon.stub().rejects(err),
+                })
+                .then(function () {
+                    true.should.eql(false);
+                })
+                .catch(function (wrappedErr) {
+                    wrappedErr.should.be.instanceof(errors.DatabaseError);
+                    wrappedErr.message.should.eql('Invalid database host.');
+                    wrappedErr.help.should.eql('Please double check your database config.');
+                });
         });
 
         it('wraps unknown connection failures', function () {
-            return database.ensureConnectionWorks({
-                raw: sinon.stub().rejects(new Error('permission denied'))
-            }).then(function () {
-                true.should.eql(false);
-            }).catch(function (wrappedErr) {
-                wrappedErr.should.be.instanceof(errors.DatabaseError);
-                wrappedErr.message.should.eql('permission denied');
-                wrappedErr.help.should.eql('Unknown database error');
-            });
+            return database
+                .ensureConnectionWorks({
+                    raw: sinon.stub().rejects(new Error('permission denied')),
+                })
+                .then(function () {
+                    true.should.eql(false);
+                })
+                .catch(function (wrappedErr) {
+                    wrappedErr.should.be.instanceof(errors.DatabaseError);
+                    wrappedErr.message.should.eql('permission denied');
+                    wrappedErr.help.should.eql('Unknown database error');
+                });
         });
     });
 
@@ -133,70 +155,80 @@ describe('Database', function () {
         it('does nothing when the migrations table already exists', function () {
             const createTable = sinon.stub();
 
-            return database.createMigrationsTable({
-                schema: {
-                    hasTable: sinon.stub().resolves(true),
-                    createTable: createTable
-                }
-            }).then(function () {
-                createTable.called.should.eql(false);
-            });
+            return database
+                .createMigrationsTable({
+                    schema: {
+                        hasTable: sinon.stub().resolves(true),
+                        createTable: createTable,
+                    },
+                })
+                .then(function () {
+                    createTable.called.should.eql(false);
+                });
         });
     });
 
     describe('createDatabaseIfNotExist', function () {
         it('rejects unsupported database clients', function () {
-            return database.createDatabaseIfNotExist({
-                client: 'postgres',
-                connection: {
-                    database: 'km_testing'
-                }
-            }).then(function () {
-                true.should.eql(false);
-            }).catch(function (err) {
-                err.should.be.instanceof(errors.KnexMigrateError);
-                err.message.should.eql('Database is not supported.');
-            });
+            return database
+                .createDatabaseIfNotExist({
+                    client: 'postgres',
+                    connection: {
+                        database: 'km_testing',
+                    },
+                })
+                .then(function () {
+                    true.should.eql(false);
+                })
+                .catch(function (err) {
+                    err.should.be.instanceof(errors.KnexMigrateError);
+                    err.message.should.eql('Database is not supported.');
+                });
         });
 
         it('ignores existing mysql databases', function () {
             const connection = {
-                raw: sinon.stub().rejects({errno: 1007}),
-                destroy: sinon.stub().callsArg(0)
+                raw: sinon.stub().rejects({ errno: 1007 }),
+                destroy: sinon.stub().callsArg(0),
             };
 
             sinon.stub(database, 'connect').returns(connection);
             sinon.stub(database, 'ensureConnectionWorks').resolves();
 
-            return database.createDatabaseIfNotExist({
-                client: 'mysql2',
-                connection: {
-                    database: 'km_testing'
-                }
-            }).then(function () {
-                connection.destroy.calledOnce.should.eql(true);
-            });
+            return database
+                .createDatabaseIfNotExist({
+                    client: 'mysql2',
+                    connection: {
+                        database: 'km_testing',
+                    },
+                })
+                .then(function () {
+                    connection.destroy.calledOnce.should.eql(true);
+                });
         });
 
         it('rejects destroy failures after mysql database creation', function () {
             const connection = {
                 raw: sinon.stub().resolves(),
-                destroy: sinon.stub().callsArgWith(0, new Error('destroy failed'))
+                destroy: sinon.stub().callsArgWith(0, new Error('destroy failed')),
             };
 
             sinon.stub(database, 'connect').returns(connection);
             sinon.stub(database, 'ensureConnectionWorks').resolves();
 
-            return database.createDatabaseIfNotExist({
-                client: 'mysql2',
-                connection: {
-                    database: 'km_testing'
-                }
-            }).then(function () {
-                true.should.eql(false);
-            }).catch(function (err) {
-                err.message.should.eql('destroy failed');
-            });
+            return database
+                .createDatabaseIfNotExist({
+                    client: 'mysql2',
+                    connection: {
+                        database: 'km_testing',
+                    },
+                })
+                .then(function () {
+                    true.should.eql(false);
+                })
+                .catch(function (err) {
+                    err.message.should.eql('destroy failed');
+                });
         });
     });
 
@@ -205,40 +237,43 @@ describe('Database', function () {
             return database.drop({
                 dbConfig: {
                     connection: {
-                        database: 'km_testing'
-                    }
+                        database: 'km_testing',
+                    },
                 },
                 connection: {
                     client: {
                         config: {
-                            client: 'mysql2'
-                        }
+                            client: 'mysql2',
+                        },
                     },
-                    raw: sinon.stub().rejects({errno: 1049})
-                }
+                    raw: sinon.stub().rejects({ errno: 1049 }),
+                },
             });
         });
 
         it('wraps mysql drop failures', function () {
-            return database.drop({
-                dbConfig: {
-                    connection: {
-                        database: 'km_testing'
-                    }
-                },
-                connection: {
-                    client: {
-                        config: {
-                            client: 'mysql2'
-                        }
+            return database
+                .drop({
+                    dbConfig: {
+                        connection: {
+                            database: 'km_testing',
+                        },
                     },
-                    raw: sinon.stub().rejects(new Error('permission denied'))
-                }
-            }).then(function () {
-                true.should.eql(false);
-            }).catch(function (err) {
-                err.should.be.instanceof(errors.KnexMigrateError);
-            });
+                    connection: {
+                        client: {
+                            config: {
+                                client: 'mysql2',
+                            },
+                        },
+                        raw: sinon.stub().rejects(new Error('permission denied')),
+                    },
+                })
+                .then(function () {
+                    true.should.eql(false);
+                })
+                .catch(function (err) {
+                    err.should.be.instanceof(errors.KnexMigrateError);
+                });
         });
 
         it('drops sqlite tables and skips sqlite_sequence', function () {
@@ -246,117 +281,124 @@ describe('Database', function () {
             const connection = {
                 client: {
                     config: {
-                        client: 'sqlite3'
-                    }
+                        client: 'sqlite3',
+                    },
                 },
-                raw: sinon.stub().resolves([
-                    {name: 'sqlite_sequence'},
-                    {name: 'migrations'}
-                ]),
+                raw: sinon.stub().resolves([{ name: 'sqlite_sequence' }, { name: 'migrations' }]),
                 schema: {
-                    dropTableIfExists: dropTableIfExists
-                }
+                    dropTableIfExists: dropTableIfExists,
+                },
             };
 
-            return database.drop({
-                dbConfig: {
-                    client: 'sqlite3'
-                },
-                connection: connection
-            }).then(function () {
-                dropTableIfExists.calledOnceWith('migrations').should.eql(true);
-            });
+            return database
+                .drop({
+                    dbConfig: {
+                        client: 'sqlite3',
+                    },
+                    connection: connection,
+                })
+                .then(function () {
+                    dropTableIfExists.calledOnceWith('migrations').should.eql(true);
+                });
         });
 
         it('restores better-sqlite foreign keys after dropping tables', function () {
             const raw = sinon.stub();
             raw.onFirstCall().resolves();
-            raw.onSecondCall().resolves([{name: 'migrations'}]);
+            raw.onSecondCall().resolves([{ name: 'migrations' }]);
             raw.onThirdCall().resolves();
 
             const connection = {
                 client: {
                     config: {
-                        client: 'better-sqlite3'
-                    }
+                        client: 'better-sqlite3',
+                    },
                 },
                 raw: raw,
                 schema: {
-                    dropTableIfExists: sinon.stub().resolves()
-                }
+                    dropTableIfExists: sinon.stub().resolves(),
+                },
             };
 
-            return database.drop({
-                dbConfig: {
-                    client: 'better-sqlite3'
-                },
-                connection: connection
-            }).then(function () {
-                raw.firstCall.calledWith('PRAGMA foreign_keys = OFF;').should.eql(true);
-                raw.thirdCall.calledWith('PRAGMA foreign_keys = ON;').should.eql(true);
-            });
+            return database
+                .drop({
+                    dbConfig: {
+                        client: 'better-sqlite3',
+                    },
+                    connection: connection,
+                })
+                .then(function () {
+                    raw.firstCall.calledWith('PRAGMA foreign_keys = OFF;').should.eql(true);
+                    raw.thirdCall.calledWith('PRAGMA foreign_keys = ON;').should.eql(true);
+                });
         });
 
         it('ignores uninitialized sqlite databases', function () {
             return database.drop({
                 dbConfig: {
-                    client: 'sqlite3'
+                    client: 'sqlite3',
                 },
                 connection: {
                     client: {
                         config: {
-                            client: 'sqlite3'
-                        }
+                            client: 'sqlite3',
+                        },
                     },
-                    raw: sinon.stub().rejects({errno: 10}),
+                    raw: sinon.stub().rejects({ errno: 10 }),
                     schema: {
-                        dropTableIfExists: sinon.stub()
-                    }
-                }
+                        dropTableIfExists: sinon.stub(),
+                    },
+                },
             });
         });
 
         it('wraps sqlite drop failures', function () {
-            return database.drop({
-                dbConfig: {
-                    client: 'sqlite3'
-                },
-                connection: {
-                    client: {
-                        config: {
-                            client: 'sqlite3'
-                        }
+            return database
+                .drop({
+                    dbConfig: {
+                        client: 'sqlite3',
                     },
-                    raw: sinon.stub().rejects(new Error('drop failed')),
-                    schema: {
-                        dropTableIfExists: sinon.stub()
-                    }
-                }
-            }).then(function () {
-                true.should.eql(false);
-            }).catch(function (err) {
-                err.should.be.instanceof(errors.KnexMigrateError);
-            });
+                    connection: {
+                        client: {
+                            config: {
+                                client: 'sqlite3',
+                            },
+                        },
+                        raw: sinon.stub().rejects(new Error('drop failed')),
+                        schema: {
+                            dropTableIfExists: sinon.stub(),
+                        },
+                    },
+                })
+                .then(function () {
+                    true.should.eql(false);
+                })
+                .catch(function (err) {
+                    err.should.be.instanceof(errors.KnexMigrateError);
+                });
         });
 
         it('rejects unsupported database clients', function () {
-            return database.drop({
-                dbConfig: {
-                    client: 'postgres'
-                },
-                connection: {
-                    client: {
-                        config: {
-                            client: 'postgres'
-                        }
-                    }
-                }
-            }).then(function () {
-                true.should.eql(false);
-            }).catch(function (err) {
-                err.should.be.instanceof(errors.KnexMigrateError);
-                err.message.should.eql('Database client not supported: postgres');
-            });
+            return database
+                .drop({
+                    dbConfig: {
+                        client: 'postgres',
+                    },
+                    connection: {
+                        client: {
+                            config: {
+                                client: 'postgres',
+                            },
+                        },
+                    },
+                })
+                .then(function () {
+                    true.should.eql(false);
+                })
+                .catch(function (err) {
+                    err.should.be.instanceof(errors.KnexMigrateError);
+                    err.message.should.eql('Database client not supported: postgres');
+                });
         });
     });
 });

--- a/test/unit/index_spec.js
+++ b/test/unit/index_spec.js
@@ -11,16 +11,16 @@ function createKnexMigrator() {
         knexMigratorConfig: {
             database: {},
             migrationPath: path.join(__dirname, '..', 'assets', 'migrations'),
-            currentVersion: '1.0'
-        }
+            currentVersion: '1.0',
+        },
     });
 }
 
 function createDeleteChain() {
     return {
         where: sinon.stub().returns({
-            delete: sinon.stub().resolves()
-        })
+            delete: sinon.stub().resolves(),
+        }),
     };
 }
 
@@ -34,8 +34,8 @@ describe('KnexMigrator', function () {
             new KnexMigrator({
                 knexMigratorConfig: {
                     migrationPath: 'migrations',
-                    currentVersion: '1.0'
-                }
+                    currentVersion: '1.0',
+                },
             });
             true.should.eql(false);
         } catch (err) {
@@ -48,12 +48,14 @@ describe('KnexMigrator', function () {
             new KnexMigrator({
                 knexMigratorConfig: {
                     database: {},
-                    currentVersion: '1.0'
-                }
+                    currentVersion: '1.0',
+                },
             });
             true.should.eql(false);
         } catch (err) {
-            err.message.should.eql('MigratorConfig.js needs to export the location of your migration files.');
+            err.message.should.eql(
+                'MigratorConfig.js needs to export the location of your migration files.',
+            );
         }
     });
 
@@ -62,8 +64,8 @@ describe('KnexMigrator', function () {
             new KnexMigrator({
                 knexMigratorConfig: {
                     database: {},
-                    migrationPath: 'migrations'
-                }
+                    migrationPath: 'migrations',
+                },
             });
             true.should.eql(false);
         } catch (err) {
@@ -78,22 +80,27 @@ describe('KnexMigrator', function () {
 
             return knexMigrator._beforeEach({
                 task: '1-test.js',
-                version: '1.0'
+                version: '1.0',
             });
         });
 
         it('rejects duplicate migrations', function () {
             const knexMigrator = createKnexMigrator();
-            knexMigrator.connection = sinon.stub().resolves([{name: '1-test.js', version: '1.0'}]);
+            knexMigrator.connection = sinon
+                .stub()
+                .resolves([{ name: '1-test.js', version: '1.0' }]);
 
-            return knexMigrator._beforeEach({
-                task: '1-test.js',
-                version: '1.0'
-            }).then(function () {
-                true.should.eql(false);
-            }).catch(function (err) {
-                err.should.be.instanceof(errors.MigrationExistsError);
-            });
+            return knexMigrator
+                ._beforeEach({
+                    task: '1-test.js',
+                    version: '1.0',
+                })
+                .then(function () {
+                    true.should.eql(false);
+                })
+                .catch(function (err) {
+                    err.should.be.instanceof(errors.MigrationExistsError);
+                });
         });
     });
 
@@ -105,9 +112,9 @@ describe('KnexMigrator', function () {
             const task = {
                 name: '1-test.js',
                 config: {
-                    transaction: true
+                    transaction: true,
                 },
-                up: sinon.stub().resolves()
+                up: sinon.stub().resolves(),
             };
             const txn = {};
 
@@ -120,58 +127,73 @@ describe('KnexMigrator', function () {
 
             const hooks = {
                 beforeEach: sinon.stub().resolves(),
-                afterEach: sinon.stub().resolves()
+                afterEach: sinon.stub().resolves(),
             };
 
-            return knexMigrator._migrateTo({
-                version: '1.0',
-                hooks: hooks
-            }).then(function (result) {
-                result.skippedTasks.should.eql([]);
-                hooks.beforeEach.calledOnce.should.eql(true);
-                hooks.afterEach.calledOnce.should.eql(true);
-                task.up.calledWith({transacting: txn}).should.eql(true);
-            });
+            return knexMigrator
+                ._migrateTo({
+                    version: '1.0',
+                    hooks: hooks,
+                })
+                .then(function (result) {
+                    result.skippedTasks.should.eql([]);
+                    hooks.beforeEach.calledOnce.should.eql(true);
+                    hooks.afterEach.calledOnce.should.eql(true);
+                    task.up.calledWith({ transacting: txn }).should.eql(true);
+                });
         });
 
         it('skips existing migrations', function () {
             const knexMigrator = createKnexMigrator();
             knexMigrator.connection = createDeleteChain;
 
-            sinon.stub(utils, 'readTasks').returns([{
-                name: '1-test.js',
-                up: sinon.stub().resolves()
-            }]);
+            sinon.stub(utils, 'readTasks').returns([
+                {
+                    name: '1-test.js',
+                    up: sinon.stub().resolves(),
+                },
+            ]);
             sinon.stub(knexMigrator, '_beforeEach').rejects(new errors.MigrationExistsError());
 
-            return knexMigrator._migrateTo({
-                version: '1.0'
-            }).then(function (result) {
-                result.skippedTasks.should.eql(['1-test.js']);
-            });
+            return knexMigrator
+                ._migrateTo({
+                    version: '1.0',
+                })
+                .then(function (result) {
+                    result.skippedTasks.should.eql(['1-test.js']);
+                });
         });
 
         it('wraps long key errors with field-length guidance', function () {
             const knexMigrator = createKnexMigrator();
             knexMigrator.connection = createDeleteChain;
 
-            const err = new Error('Specified key was too long for index `table_name`.`idx_name`.`field_name`');
+            const err = new Error(
+                'Specified key was too long for index `table_name`.`idx_name`.`field_name`',
+            );
             err.code = 'ER_TOO_LONG_KEY';
 
-            sinon.stub(utils, 'readTasks').returns([{
-                name: '1-test.js',
-                up: sinon.stub().rejects(err)
-            }]);
+            sinon.stub(utils, 'readTasks').returns([
+                {
+                    name: '1-test.js',
+                    up: sinon.stub().rejects(err),
+                },
+            ]);
             sinon.stub(knexMigrator, '_beforeEach').resolves();
 
-            return knexMigrator._migrateTo({
-                version: '1.0'
-            }).then(function () {
-                true.should.eql(false);
-            }).catch(function (wrappedErr) {
-                wrappedErr.should.be.instanceof(errors.MigrationScriptError);
-                wrappedErr.message.should.eql('Field length of `field_name` in `table_name` is too long!');
-            });
+            return knexMigrator
+                ._migrateTo({
+                    version: '1.0',
+                })
+                .then(function () {
+                    true.should.eql(false);
+                })
+                .catch(function (wrappedErr) {
+                    wrappedErr.should.be.instanceof(errors.MigrationScriptError);
+                    wrappedErr.message.should.eql(
+                        'Field length of `field_name` in `table_name` is too long!',
+                    );
+                });
         });
 
         it('runs only the requested task when only is set', function () {
@@ -180,24 +202,26 @@ describe('KnexMigrator', function () {
 
             const skippedTask = {
                 name: '1-test.js',
-                up: sinon.stub().resolves()
+                up: sinon.stub().resolves(),
             };
             const selectedTask = {
                 name: '2-test.js',
-                up: sinon.stub().resolves()
+                up: sinon.stub().resolves(),
             };
 
             sinon.stub(utils, 'readTasks').returns([skippedTask, selectedTask]);
             sinon.stub(knexMigrator, '_beforeEach').resolves();
             sinon.stub(knexMigrator, '_afterEach').resolves();
 
-            return knexMigrator._migrateTo({
-                version: '1.0',
-                only: 2
-            }).then(function () {
-                skippedTask.up.called.should.eql(false);
-                selectedTask.up.calledOnce.should.eql(true);
-            });
+            return knexMigrator
+                ._migrateTo({
+                    version: '1.0',
+                    only: 2,
+                })
+                .then(function () {
+                    skippedTask.up.called.should.eql(false);
+                    selectedTask.up.calledOnce.should.eql(true);
+                });
         });
 
         it('skips the requested task when skip is set', function () {
@@ -206,24 +230,26 @@ describe('KnexMigrator', function () {
 
             const skippedTask = {
                 name: '1-test.js',
-                up: sinon.stub().resolves()
+                up: sinon.stub().resolves(),
             };
             const selectedTask = {
                 name: '2-test.js',
-                up: sinon.stub().resolves()
+                up: sinon.stub().resolves(),
             };
 
             sinon.stub(utils, 'readTasks').returns([skippedTask, selectedTask]);
             sinon.stub(knexMigrator, '_beforeEach').resolves();
             sinon.stub(knexMigrator, '_afterEach').resolves();
 
-            return knexMigrator._migrateTo({
-                version: '1.0',
-                skip: 1
-            }).then(function () {
-                skippedTask.up.called.should.eql(false);
-                selectedTask.up.calledOnce.should.eql(true);
-            });
+            return knexMigrator
+                ._migrateTo({
+                    version: '1.0',
+                    skip: 1,
+                })
+                .then(function () {
+                    skippedTask.up.called.should.eql(false);
+                    selectedTask.up.calledOnce.should.eql(true);
+                });
         });
     });
 
@@ -231,15 +257,18 @@ describe('KnexMigrator', function () {
         it('reports a missing target database', function () {
             const knexMigrator = createKnexMigrator();
             knexMigrator.connection = sinon.stub().returns({
-                select: sinon.stub().throws({errno: 1046})
+                select: sinon.stub().throws({ errno: 1046 }),
             });
 
-            return knexMigrator._integrityCheck({}).then(function () {
-                true.should.eql(false);
-            }).catch(function (err) {
-                err.should.be.instanceof(errors.DatabaseIsNotOkError);
-                err.code.should.eql('DB_NOT_INITIALISED');
-            });
+            return knexMigrator
+                ._integrityCheck({})
+                .then(function () {
+                    true.should.eql(false);
+                })
+                .catch(function (err) {
+                    err.should.be.instanceof(errors.DatabaseIsNotOkError);
+                    err.code.should.eql('DB_NOT_INITIALISED');
+                });
         });
 
         it('reports a missing migrations table', function () {
@@ -247,30 +276,36 @@ describe('KnexMigrator', function () {
             knexMigrator.connection = sinon.stub().returns({
                 select: sinon.stub().throws({
                     code: 'SQLITE_ERROR',
-                    message: 'no such table: migrations'
-                })
+                    message: 'no such table: migrations',
+                }),
             });
 
-            return knexMigrator._integrityCheck({}).then(function () {
-                true.should.eql(false);
-            }).catch(function (err) {
-                err.should.be.instanceof(errors.DatabaseIsNotOkError);
-                err.code.should.eql('MIGRATION_TABLE_IS_MISSING');
-            });
+            return knexMigrator
+                ._integrityCheck({})
+                .then(function () {
+                    true.should.eql(false);
+                })
+                .catch(function (err) {
+                    err.should.be.instanceof(errors.DatabaseIsNotOkError);
+                    err.code.should.eql('MIGRATION_TABLE_IS_MISSING');
+                });
         });
 
         it('reports a missing mysql database', function () {
             const knexMigrator = createKnexMigrator();
             knexMigrator.connection = sinon.stub().returns({
-                select: sinon.stub().throws({errno: 1049})
+                select: sinon.stub().throws({ errno: 1049 }),
             });
 
-            return knexMigrator._integrityCheck({}).then(function () {
-                true.should.eql(false);
-            }).catch(function (err) {
-                err.should.be.instanceof(errors.DatabaseIsNotOkError);
-                err.code.should.eql('DB_NOT_INITIALISED');
-            });
+            return knexMigrator
+                ._integrityCheck({})
+                .then(function () {
+                    true.should.eql(false);
+                })
+                .catch(function (err) {
+                    err.should.be.instanceof(errors.DatabaseIsNotOkError);
+                    err.code.should.eql('DB_NOT_INITIALISED');
+                });
         });
     });
 });

--- a/test/unit/locking_spec.js
+++ b/test/unit/locking_spec.js
@@ -11,9 +11,9 @@ function createLockTable(data) {
                 forUpdate: sinon.stub().returns({
                     then: function (callback) {
                         return Promise.resolve(data).then(callback);
-                    }
-                })
-            })
+                    },
+                }),
+            }),
         };
     };
 }
@@ -22,8 +22,8 @@ function createRejectedLockTable(err) {
     return function lockTable() {
         return {
             where: sinon.stub().returns({
-                forUpdate: sinon.stub().returns(Promise.reject(err))
-            })
+                forUpdate: sinon.stub().returns(Promise.reject(err)),
+            }),
         };
     };
 }
@@ -39,11 +39,14 @@ describe('Locking', function () {
                 return callback(createLockTable([]));
             });
 
-            return locking.lock({}).then(function () {
-                true.should.eql(false);
-            }).catch(function (err) {
-                err.should.be.instanceof(errors.MigrationsAreLockedError);
-            });
+            return locking
+                .lock({})
+                .then(function () {
+                    true.should.eql(false);
+                })
+                .catch(function (err) {
+                    err.should.be.instanceof(errors.MigrationsAreLockedError);
+                });
         });
 
         it('wraps unexpected lock acquisition errors', function () {
@@ -51,19 +54,22 @@ describe('Locking', function () {
                 return callback(createRejectedLockTable(new Error('driver failed')));
             });
 
-            return locking.lock({}).then(function () {
-                true.should.eql(false);
-            }).catch(function (err) {
-                err.should.be.instanceof(errors.LockError);
-                err.message.should.eql('Error while acquire the migration lock.');
-            });
+            return locking
+                .lock({})
+                .then(function () {
+                    true.should.eql(false);
+                })
+                .catch(function (err) {
+                    err.should.be.instanceof(errors.LockError);
+                    err.message.should.eql('Error while acquire the migration lock.');
+                });
         });
     });
 
     describe('isLocked', function () {
         it('returns false when the lock is released', function () {
             const connection = sinon.stub().returns({
-                where: sinon.stub().resolves([{locked: 0}])
+                where: sinon.stub().resolves([{ locked: 0 }]),
             });
 
             return locking.isLocked(connection).then(function (result) {
@@ -73,28 +79,34 @@ describe('Locking', function () {
 
         it('rejects when the lock row is locked', function () {
             const connection = sinon.stub().returns({
-                where: sinon.stub().resolves([{locked: 1}])
+                where: sinon.stub().resolves([{ locked: 1 }]),
             });
 
-            return locking.isLocked(connection).then(function () {
-                true.should.eql(false);
-            }).catch(function (err) {
-                err.should.be.instanceof(errors.MigrationsAreLockedError);
-            });
+            return locking
+                .isLocked(connection)
+                .then(function () {
+                    true.should.eql(false);
+                })
+                .catch(function (err) {
+                    err.should.be.instanceof(errors.MigrationsAreLockedError);
+                });
         });
     });
 
     describe('unlock', function () {
         it('rejects when the migration lock row is already released', function () {
             sinon.stub(database, 'createTransaction').callsFake(function (connection, callback) {
-                return callback(createLockTable([{locked: 0}]));
+                return callback(createLockTable([{ locked: 0 }]));
             });
 
-            return locking.unlock({}).then(function () {
-                true.should.eql(false);
-            }).catch(function (err) {
-                err.should.be.instanceof(errors.MigrationsAreLockedError);
-            });
+            return locking
+                .unlock({})
+                .then(function () {
+                    true.should.eql(false);
+                })
+                .catch(function (err) {
+                    err.should.be.instanceof(errors.MigrationsAreLockedError);
+                });
         });
 
         it('wraps unexpected unlock errors', function () {
@@ -102,12 +114,15 @@ describe('Locking', function () {
                 return callback(createRejectedLockTable(new Error('driver failed')));
             });
 
-            return locking.unlock({}).then(function () {
-                true.should.eql(false);
-            }).catch(function (err) {
-                err.should.be.instanceof(errors.UnlockError);
-                err.message.should.eql('Error while releasing the migration lock.');
-            });
+            return locking
+                .unlock({})
+                .then(function () {
+                    true.should.eql(false);
+                })
+                .catch(function (err) {
+                    err.should.be.instanceof(errors.UnlockError);
+                    err.message.should.eql('Error while releasing the migration lock.');
+                });
         });
     });
 });

--- a/test/unit/migrations_spec.js
+++ b/test/unit/migrations_spec.js
@@ -10,13 +10,13 @@ describe('Migrations', function () {
             const connection = {
                 client: {
                     config: {
-                        client: 'sqlite3'
-                    }
+                        client: 'sqlite3',
+                    },
                 },
-                raw: sinon.stub().resolves([{origin: 'pk'}]),
+                raw: sinon.stub().resolves([{ origin: 'pk' }]),
                 schema: {
-                    table: table
-                }
+                    table: table,
+                },
             };
 
             return addPrimaryKeyToLockTable.up(connection).then(function () {
@@ -31,12 +31,12 @@ describe('Migrations', function () {
             const connection = {
                 client: {
                     config: {
-                        client: 'mysql2'
-                    }
+                        client: 'mysql2',
+                    },
                 },
                 schema: {
-                    table: sinon.stub().rejects(duplicatePrimaryKeyError)
-                }
+                    table: sinon.stub().rejects(duplicatePrimaryKeyError),
+                },
             };
 
             return addPrimaryKeyToLockTable.up(connection);
@@ -46,32 +46,35 @@ describe('Migrations', function () {
             const connection = {
                 client: {
                     config: {
-                        client: 'mysql2'
-                    }
+                        client: 'mysql2',
+                    },
                 },
                 schema: {
-                    table: sinon.stub().rejects(new Error('table missing'))
-                }
+                    table: sinon.stub().rejects(new Error('table missing')),
+                },
             };
 
-            return addPrimaryKeyToLockTable.up(connection).then(function () {
-                true.should.eql(false);
-            }).catch(function (err) {
-                err.message.should.eql('table missing');
-            });
+            return addPrimaryKeyToLockTable
+                .up(connection)
+                .then(function () {
+                    true.should.eql(false);
+                })
+                .catch(function (err) {
+                    err.message.should.eql('table missing');
+                });
         });
     });
 
     describe('lock-table', function () {
         it('creates the migration lock table', function () {
             const primary = sinon.stub();
-            const nullable = sinon.stub().returns({primary: primary});
+            const nullable = sinon.stub().returns({ primary: primary });
             const defaultValue = sinon.stub();
-            const string = sinon.stub().returns({nullable: nullable});
-            const boolean = sinon.stub().returns({default: defaultValue});
-            const dateTime = sinon.stub().returns({nullable: sinon.stub()});
+            const string = sinon.stub().returns({ nullable: nullable });
+            const boolean = sinon.stub().returns({ default: defaultValue });
+            const dateTime = sinon.stub().returns({ nullable: sinon.stub() });
             const insert = sinon.stub().resolves();
-            const connection = sinon.stub().returns({insert: insert});
+            const connection = sinon.stub().returns({ insert: insert });
 
             connection.schema = {
                 hasTable: sinon.stub().resolves(false),
@@ -80,10 +83,10 @@ describe('Migrations', function () {
                     callback({
                         string: string,
                         boolean: boolean,
-                        dateTime: dateTime
+                        dateTime: dateTime,
                     });
                     return Promise.resolve();
-                })
+                }),
             };
 
             return lockTable.up(connection).then(function () {
@@ -95,10 +98,12 @@ describe('Migrations', function () {
                 dateTime.calledWith('acquired_at').should.eql(true);
                 dateTime.calledWith('released_at').should.eql(true);
                 connection.calledWith('migrations_lock').should.eql(true);
-                insert.calledWith({
-                    lock_key: 'km01',
-                    locked: 0
-                }).should.eql(true);
+                insert
+                    .calledWith({
+                        lock_key: 'km01',
+                        locked: 0,
+                    })
+                    .should.eql(true);
             });
         });
 
@@ -106,8 +111,8 @@ describe('Migrations', function () {
             const connection = {
                 schema: {
                     hasTable: sinon.stub().resolves(true),
-                    createTable: sinon.stub()
-                }
+                    createTable: sinon.stub(),
+                },
             };
 
             return lockTable.up(connection).then(function () {

--- a/test/unit/utils_spec.js
+++ b/test/unit/utils_spec.js
@@ -14,23 +14,27 @@ describe('Utils', function () {
             const config = {
                 database: {},
                 migrationPath: 'migrations',
-                currentVersion: '1.0'
+                currentVersion: '1.0',
             };
 
-            utils.loadConfig({
-                knexMigratorConfig: config
-            }).should.eql(config);
+            utils
+                .loadConfig({
+                    knexMigratorConfig: config,
+                })
+                .should.eql(config);
         });
 
         it('throws a helpful error when MigratorConfig.js is missing', function () {
             try {
                 utils.loadConfig({
-                    knexMigratorFilePath: path.join(__dirname, 'missing-config')
+                    knexMigratorFilePath: path.join(__dirname, 'missing-config'),
                 });
                 true.should.eql(false);
             } catch (err) {
                 should.not.exist(err.code);
-                err.message.should.eql('Please provide a file named MigratorConfig.js in your project root.');
+                err.message.should.eql(
+                    'Please provide a file named MigratorConfig.js in your project root.',
+                );
             }
         });
 
@@ -39,11 +43,13 @@ describe('Utils', function () {
 
             try {
                 utils.loadConfig({
-                    knexMigratorFilePath: configPath
+                    knexMigratorFilePath: configPath,
                 });
                 true.should.eql(false);
             } catch (err) {
-                err.message.should.not.eql('Please provide a file named MigratorConfig.js in your project root.');
+                err.message.should.not.eql(
+                    'Please provide a file named MigratorConfig.js in your project root.',
+                );
                 err.code.should.eql('MODULE_NOT_FOUND');
                 err.stack.should.match(/Cannot find module 'missing-config-dependency'/);
             }
@@ -52,149 +58,188 @@ describe('Utils', function () {
 
     describe('getKnexMigrator', function () {
         it('resolves with path to installation of knex-migrator', function (done) {
-            utils.getKnexMigrator({path: process.cwd()})
-                .then((constructor) => {
-                    constructor.name.should.eql('KnexMigrator');
-                    done();
-                });
+            utils.getKnexMigrator({ path: process.cwd() }).then((constructor) => {
+                constructor.name.should.eql('KnexMigrator');
+                done();
+            });
         });
     });
 
     describe('isGreaterThanVersion', function () {
         it('version has this notation: 1.1', function () {
-            utils.isGreaterThanVersion({
-                greaterVersion: '1.1',
-                smallerVersion: '1.0'
-            }).should.eql(true);
+            utils
+                .isGreaterThanVersion({
+                    greaterVersion: '1.1',
+                    smallerVersion: '1.0',
+                })
+                .should.eql(true);
 
-            utils.isGreaterThanVersion({
-                greaterVersion: '2.0',
-                smallerVersion: '1.0'
-            }).should.eql(true);
+            utils
+                .isGreaterThanVersion({
+                    greaterVersion: '2.0',
+                    smallerVersion: '1.0',
+                })
+                .should.eql(true);
 
-            utils.isGreaterThanVersion({
-                greaterVersion: '1.0',
-                smallerVersion: '2.0'
-            }).should.eql(false);
+            utils
+                .isGreaterThanVersion({
+                    greaterVersion: '1.0',
+                    smallerVersion: '2.0',
+                })
+                .should.eql(false);
 
-            utils.isGreaterThanVersion({
-                greaterVersion: '1.11',
-                smallerVersion: '1.4'
-            }).should.eql(true);
+            utils
+                .isGreaterThanVersion({
+                    greaterVersion: '1.11',
+                    smallerVersion: '1.4',
+                })
+                .should.eql(true);
         });
 
         it('version has this notation: 11', function () {
-            utils.isGreaterThanVersion({
-                greaterVersion: '11',
-                smallerVersion: '10'
-            }).should.eql(true);
+            utils
+                .isGreaterThanVersion({
+                    greaterVersion: '11',
+                    smallerVersion: '10',
+                })
+                .should.eql(true);
 
-            utils.isGreaterThanVersion({
-                greaterVersion: '20',
-                smallerVersion: '10'
-            }).should.eql(true);
+            utils
+                .isGreaterThanVersion({
+                    greaterVersion: '20',
+                    smallerVersion: '10',
+                })
+                .should.eql(true);
 
-            utils.isGreaterThanVersion({
-                greaterVersion: '10',
-                smallerVersion: '20'
-            }).should.eql(false);
+            utils
+                .isGreaterThanVersion({
+                    greaterVersion: '10',
+                    smallerVersion: '20',
+                })
+                .should.eql(false);
         });
 
         it('version has this notation: 11 (INT)', function () {
-            utils.isGreaterThanVersion({
-                greaterVersion: 11,
-                smallerVersion: 10
-            }).should.eql(true);
+            utils
+                .isGreaterThanVersion({
+                    greaterVersion: 11,
+                    smallerVersion: 10,
+                })
+                .should.eql(true);
 
-            utils.isGreaterThanVersion({
-                greaterVersion: 20,
-                smallerVersion: 10
-            }).should.eql(true);
+            utils
+                .isGreaterThanVersion({
+                    greaterVersion: 20,
+                    smallerVersion: 10,
+                })
+                .should.eql(true);
 
-            utils.isGreaterThanVersion({
-                greaterVersion: 10,
-                smallerVersion: 20
-            }).should.eql(false);
+            utils
+                .isGreaterThanVersion({
+                    greaterVersion: 10,
+                    smallerVersion: 20,
+                })
+                .should.eql(false);
         });
 
         it('version has this notation: 1.1.1', function () {
-            utils.isGreaterThanVersion({
-                greaterVersion: '1.1.2',
-                smallerVersion: '1.1.1'
-            }).should.eql(true);
-
-            utils.isGreaterThanVersion({
-                greaterVersion: '2.0.0',
-                smallerVersion: '1.0.0'
-            }).should.eql(true);
-
-            utils.isGreaterThanVersion({
-                greaterVersion: '1.0.0',
-                smallerVersion: '2.0.0'
-            }).should.eql(false);
+            utils
+                .isGreaterThanVersion({
+                    greaterVersion: '1.1.2',
+                    smallerVersion: '1.1.1',
+                })
+                .should.eql(true);
 
             utils
                 .isGreaterThanVersion({
                     greaterVersion: '2.0.0',
-                    smallerVersion: '1.0.10'
+                    smallerVersion: '1.0.0',
+                })
+                .should.eql(true);
+
+            utils
+                .isGreaterThanVersion({
+                    greaterVersion: '1.0.0',
+                    smallerVersion: '2.0.0',
+                })
+                .should.eql(false);
+
+            utils
+                .isGreaterThanVersion({
+                    greaterVersion: '2.0.0',
+                    smallerVersion: '1.0.10',
                 })
                 .should.eql(true);
 
             utils
                 .isGreaterThanVersion({
                     greaterVersion: '1.10.0',
-                    smallerVersion: '1.2.0'
+                    smallerVersion: '1.2.0',
                 })
                 .should.eql(true);
         });
 
         it('version has this notation: 1', function () {
-            utils.isGreaterThanVersion({
-                greaterVersion: '1',
-                smallerVersion: '1'
-            }).should.eql(false);
+            utils
+                .isGreaterThanVersion({
+                    greaterVersion: '1',
+                    smallerVersion: '1',
+                })
+                .should.eql(false);
 
-            utils.isGreaterThanVersion({
-                greaterVersion: '2',
-                smallerVersion: '1'
-            }).should.eql(true);
+            utils
+                .isGreaterThanVersion({
+                    greaterVersion: '2',
+                    smallerVersion: '1',
+                })
+                .should.eql(true);
 
-            utils.isGreaterThanVersion({
-                greaterVersion: '1',
-                smallerVersion: '2'
-            }).should.eql(false);
+            utils
+                .isGreaterThanVersion({
+                    greaterVersion: '1',
+                    smallerVersion: '2',
+                })
+                .should.eql(false);
         });
     });
 
     describe('readFolders', function () {
         it('ensure order', function () {
             sinon.stub(fs, 'readdirSync').returns(['1.0', '2.0', '2.3', '2.13']);
-            let folders = utils.readVersionFolders(path.join(__dirname, 'assets', 'migrations', 'versions'));
+            let folders = utils.readVersionFolders(
+                path.join(__dirname, 'assets', 'migrations', 'versions'),
+            );
             folders.should.eql(['1.0', '2.0', '2.3', '2.13']);
         });
 
         it('ensure order', function () {
             sinon.stub(fs, 'readdirSync').returns(['1.1.2', '1.1.0', '0.1']);
-            let folders = utils.readVersionFolders(path.join(__dirname, 'assets', 'migrations', 'versions'));
+            let folders = utils.readVersionFolders(
+                path.join(__dirname, 'assets', 'migrations', 'versions'),
+            );
             folders.should.eql(['0.1', '1.1.0', '1.1.2']);
         });
 
         it('ensure order', function () {
-            sinon.stub(fs, 'readdirSync').returns([
-                '1.13',
-                '1.18',
-                '1.19',
-                '1.20',
-                '1.21',
-                '1.22',
-                '1.3',
-                '1.4',
-                '1.5',
-                '1.7',
-                '1.9'
-            ]);
+            sinon
+                .stub(fs, 'readdirSync')
+                .returns([
+                    '1.13',
+                    '1.18',
+                    '1.19',
+                    '1.20',
+                    '1.21',
+                    '1.22',
+                    '1.3',
+                    '1.4',
+                    '1.5',
+                    '1.7',
+                    '1.9',
+                ]);
 
-            let folders = utils.readVersionFolders(path.join(__dirname, 'assets', 'migrations', 'versions'));
+            let folders = utils.readVersionFolders(
+                path.join(__dirname, 'assets', 'migrations', 'versions'),
+            );
 
             folders.should.eql([
                 '1.3',
@@ -207,19 +252,23 @@ describe('Utils', function () {
                 '1.19',
                 '1.20',
                 '1.21',
-                '1.22'
+                '1.22',
             ]);
         });
 
         it('ignores dot folders', function () {
             sinon.stub(fs, 'readdirSync').returns(['.DS_Store', '1.0']);
-            let folders = utils.readVersionFolders(path.join(__dirname, 'assets', 'migrations', 'versions'));
+            let folders = utils.readVersionFolders(
+                path.join(__dirname, 'assets', 'migrations', 'versions'),
+            );
             folders.should.eql(['1.0']);
         });
 
         it('returns an empty folder list directly', function () {
             sinon.stub(fs, 'readdirSync').returns([]);
-            let folders = utils.readVersionFolders(path.join(__dirname, 'assets', 'migrations', 'versions'));
+            let folders = utils.readVersionFolders(
+                path.join(__dirname, 'assets', 'migrations', 'versions'),
+            );
             folders.should.eql([]);
         });
     });

--- a/test/utils.js
+++ b/test/utils.js
@@ -17,23 +17,33 @@ exports.writeMigratorConfig = function writeMigratorConfig(options) {
     let migratorConfig = {
         database: config.get('database'),
         migrationPath: options.migrationPath,
-        currentVersion: options.currentVersion
+        currentVersion: options.currentVersion,
     };
 
-    fs.writeFileSync(options.migratorConfigPath, 'module.exports = ' + JSON.stringify(migratorConfig) + ';', 'utf-8');
+    fs.writeFileSync(
+        options.migratorConfigPath,
+        'module.exports = ' + JSON.stringify(migratorConfig) + ';',
+        'utf-8',
+    );
 };
 
 exports.generateMigrationScript = function (options) {
     let up = options.up,
         down = options.down;
 
-    let script = 'module.exports.up = function something(options) {' +
-        'return options.connection.raw(' + JSON.stringify(up) + ');' +
+    let script =
+        'module.exports.up = function something(options) {' +
+        'return options.connection.raw(' +
+        JSON.stringify(up) +
+        ');' +
         '};';
 
     if (options.down) {
-        script += 'module.exports.down = function something(options) {' +
-            'return options.connection.raw(' + JSON.stringify(down) + ');' +
+        script +=
+            'module.exports.down = function something(options) {' +
+            'return options.connection.raw(' +
+            JSON.stringify(down) +
+            ');' +
             '};';
     }
 


### PR DESCRIPTION
## Summary
- replace the legacy ESLint 6 setup with `oxlint@1.72.0` and `oxfmt@0.57.0`
- add Clean Repos baseline ox configs with Node runtime globals, a Mocha test override for should-style assertions/fixtures, and a smoke-script logging override
- remove old ESLint configs/dependencies/cache ignore and apply the formatter across JavaScript source, migrations, scripts, and tests
- move lint/format validation into a dedicated CI job and require it from `All tests pass`

ref [GVA-821](https://linear.app/ghost/issue/GVA-821/clean-repos-knex-migrator)

## Validation
- `corepack pnpm install --frozen-lockfile`
- `corepack pnpm lint`
- `corepack pnpm coverage`
- `NODE_ENV=testing-better-sqlite3 corepack pnpm coverage`
- `GHOST_CORE_PATH=/Users/aileen/code/tryghost/Ghost corepack pnpm smoke:ghost`
- `jq . package.json >/dev/null && jq . .oxlintrc.json >/dev/null && jq . .oxfmtrc.json >/dev/null && git diff --check`
- stale ESLint/Prettier reference sweep with `rg` returned no matches
