### PR TITLE
Pin CI Node versions in Renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -10,6 +10,39 @@
         "knex"
       ],
       "allowedVersions": "2.4.2"
+    },
+    {
+      "description": "Keep CI runtime jobs pinned to Node 22.13.1; .nvmrc may still move independently.",
+      "matchManagers": [
+        "github-actions"
+      ],
+      "matchPackageNames": [
+        "node"
+      ],
+      "matchCurrentValue": "22.13.1",
+      "allowedVersions": "22.13.1"
+    },
+    {
+      "description": "Keep the Ghost consumer smoke pinned to Node 22.18.0; it follows Ghost's checked-in runtime separately from .nvmrc.",
+      "matchManagers": [
+        "github-actions"
+      ],
+      "matchPackageNames": [
+        "node"
+      ],
+      "matchCurrentValue": "22.18.0",
+      "allowedVersions": "22.18.0"
+    },
+    {
+      "description": "Keep the next-runtime CI lane pinned to Node 24.14.1 until we intentionally move it.",
+      "matchManagers": [
+        "github-actions"
+      ],
+      "matchPackageNames": [
+        "node"
+      ],
+      "matchCurrentValue": "24.14.1",
+      "allowedVersions": "24.14.1"
     }
   ]
 }


### PR DESCRIPTION
## Summary

- pin Renovate updates for GitHub Actions Node versions used by CI
- keep the existing shared preset and knex compatibility guard
- leave .nvmrc updates eligible by scoping the new Node rules to the github-actions manager

## Rationale

Renovate PR #434 updates both .nvmrc and CI workflow Node pins. The .nvmrc move is fine, but the workflow values are intentional runtime pins for the test matrix and Ghost consumer smoke check. Freezing the github-actions Node values keeps CI on the runtimes we deliberately test until we choose to move them.

Shared preset: `local>TryGhost/renovate-config`

Config location: `.github/renovate.json` remains unchanged.

Retained overrides:
- `knex` stays pinned to `2.4.2` to match the Ghost current catalog version.

Added overrides:
- `node@22.13.1` for GitHub Actions lint and test jobs
- `node@22.18.0` for the Ghost consumer smoke job
- `node@24.14.1` for the next-runtime CI lane

These rules use `matchManagers: ["github-actions"]`, so Renovate can still update `.nvmrc` independently.

## Verification

- `jq . .github/renovate.json`
- `git diff --check`
- `corepack pnpm dlx --package renovate renovate-config-validator .github/renovate.json`

ref [GVA-821](https://linear.app/ghost/issue/GVA-821/clean-repos-knex-migrator)