### PR TITLE
Changed `sqlite3` client to transparently use `better-sqlite3`

### DIFF
--- a/lib/database.js
+++ b/lib/database.js
@@ -48,9 +48,14 @@ exports.connect = function connect(options, connectionOptions) {
         options.client = 'mysql2';
     }
 
+    // Alias `sqlite3` to `better-sqlite3` so we can maintain backwards compatibility
+    if (options.client === 'sqlite3') {
+        options.client = 'better-sqlite3';
+    }
+
     const client = options.client;
 
-    if (client === 'sqlite3') {
+    if (client === 'better-sqlite3') {
         options.useNullAsDefault = options.useNullAsDefault || false;
     }
 

--- a/test/unit/database_spec.js
+++ b/test/unit/database_spec.js
@@ -30,6 +30,19 @@ describe('Database', function () {
             return connection.destroy();
         });
 
+        it('aliases sqlite3 configs to better-sqlite3', function () {
+            const connection = database.connect({
+                client: 'sqlite3',
+                connection: {
+                    filename: ':memory:',
+                },
+            });
+
+            connection.client.config.client.should.eql('better-sqlite3');
+
+            return connection.destroy();
+        });
+
         it('preserves explicit sqlite useNullAsDefault', function () {
             const connection = database.connect({
                 client: 'sqlite3',
@@ -78,7 +91,7 @@ describe('Database', function () {
                 );
 
                 connection.loadedFromProject.should.eql(true);
-                connection.client.config.client.should.eql('sqlite3');
+                connection.client.config.client.should.eql('better-sqlite3');
             } finally {
                 fs.rmSync(projectPath, { recursive: true, force: true });
             }
@@ -134,7 +147,7 @@ describe('Database', function () {
                     },
                 );
 
-                connection.client.config.client.should.eql('sqlite3');
+                connection.client.config.client.should.eql('better-sqlite3');
                 return connection.destroy();
             } finally {
                 fs.rmSync(projectPath, { recursive: true, force: true });


### PR DESCRIPTION
The `sqlite3` native module is increasingly painful to build and maintain, while `better-sqlite3` is the actively maintained successor. Aliasing `sqlite3` to `better-sqlite3` at connect time (mirroring the existing `mysql` -> `mysql2` alias) lets existing `client: 'sqlite3'` configs keep working without any change while routing them through the better-maintained driver. Note this means foreign key constraints are now enforced, since `better-sqlite3` ships with them enabled by default.