### PR TITLE
Fix Renovate Node workflow pin matching

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -16,8 +16,14 @@
       "matchManagers": [
         "github-actions"
       ],
-      "matchPackageNames": [
+      "matchDepTypes": [
+        "uses-with"
+      ],
+      "matchDepNames": [
         "node"
+      ],
+      "matchPackageNames": [
+        "actions/node-versions"
       ],
       "matchCurrentValue": "22.13.1",
       "allowedVersions": "22.13.1"
@@ -27,8 +33,14 @@
       "matchManagers": [
         "github-actions"
       ],
-      "matchPackageNames": [
+      "matchDepTypes": [
+        "uses-with"
+      ],
+      "matchDepNames": [
         "node"
+      ],
+      "matchPackageNames": [
+        "actions/node-versions"
       ],
       "matchCurrentValue": "22.18.0",
       "allowedVersions": "22.18.0"
@@ -38,8 +50,14 @@
       "matchManagers": [
         "github-actions"
       ],
-      "matchPackageNames": [
+      "matchDepTypes": [
+        "uses-with"
+      ],
+      "matchDepNames": [
         "node"
+      ],
+      "matchPackageNames": [
+        "actions/node-versions"
       ],
       "matchCurrentValue": "24.14.1",
       "allowedVersions": "24.14.1"


### PR DESCRIPTION
## Summary

- update the Renovate package rules for pinned CI Node versions to match `actions/setup-node` `node-version` dependencies as Renovate extracts them
- keep the rules scoped to GitHub Actions `uses-with` dependencies so `.nvmrc` updates can still move independently
- covers the workflow changes attempted by Renovate PRs #383 and #434

## Root cause

Renovate extracts `actions/setup-node` `node-version` inputs as `depName: node`, `packageName: actions/node-versions`, and `depType: uses-with`. The previous rules used `matchPackageNames: ["node"]`, so they did not match those workflow entries and Renovate still opened PRs changing the pinned workflow versions.

## Validation

- `node -e "JSON.parse(require('fs').readFileSync('.github/renovate.json', 'utf8'))"`
- `nvm exec 24.17.0 npx --yes --package renovate@43.242.2 renovate-config-validator .github/renovate.json`