### PR TITLE
Improved async flow in knex-migrator

### DIFF
--- a/bin/knex-migrator
+++ b/bin/knex-migrator
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
-var program = require('commander').program,
-    pkg = require('../package.json');
+const program = require('commander').program;
+const pkg = require('../package.json');
 
 program
     .version(pkg.version, '-v, --version')

--- a/bin/knex-migrator-health
+++ b/bin/knex-migrator-health
@@ -1,32 +1,35 @@
 #!/usr/bin/env node
 
-var program = require('commander').program;
-var utils = require('../lib/utils');
+const program = require('commander').program;
+const utils = require('../lib/utils');
 
-var logging = require('@tryghost/logging');
-var knexMigrator;
+const logging = require('@tryghost/logging');
 
-utils.getKnexMigrator({path: process.cwd()})
-    .then(function (KnexMigrator) {
-        program
-            .option('--mgpath <path>')
-            .parse(process.argv);
+async function main() {
+    const KnexMigrator = await utils.getKnexMigrator({path: process.cwd()});
 
-        var options = program.opts();
+    program
+        .option('--mgpath <path>')
+        .parse(process.argv);
 
-        try {
-            knexMigrator = new KnexMigrator({knexMigratorFilePath: options.mgpath, executedFromShell: true});
-        } catch (err) {
-            logging.error(err);
-            process.exit(1);
-        }
+    const options = program.opts();
+    let knexMigrator;
 
-        return knexMigrator.isDatabaseOK()
-            .then(function () {
-                logging.info('Woohoo, Database is healthy');
-            });
-    })
-    .catch(function (err) {
+    try {
+        knexMigrator = new KnexMigrator({
+            knexMigratorFilePath: options.mgpath,
+            executedFromShell: true,
+        });
+    } catch (err) {
+        logging.error(err);
+        process.exit(1);
+    }
+
+    await knexMigrator.isDatabaseOK();
+    logging.info('Woohoo, Database is healthy');
+}
+
+main().catch(function (err) {
         logging.error(err.message);
 
         if (err.help) {

--- a/bin/knex-migrator-init
+++ b/bin/knex-migrator-init
@@ -1,36 +1,40 @@
 #!/usr/bin/env node
 
-var program = require('commander').program;
-var utils = require('../lib/utils');
+const program = require('commander').program;
+const utils = require('../lib/utils');
 
-var logging = require('@tryghost/logging');
-var knexMigrator;
+const logging = require('@tryghost/logging');
 
-utils.getKnexMigrator({path: process.cwd()})
-    .then(function (KnexMigrator) {
-        program
-            .option('--skip <item>')
-            .option('--only <item>')
-            .option('--mgpath <path>')
-            .parse(process.argv);
+async function main() {
+    const KnexMigrator = await utils.getKnexMigrator({path: process.cwd()});
 
-        var options = program.opts();
+    program
+        .option('--skip <item>')
+        .option('--only <item>')
+        .option('--mgpath <path>')
+        .parse(process.argv);
 
-        try {
-            knexMigrator = new KnexMigrator({knexMigratorFilePath: options.mgpath, executedFromShell: true});
-        } catch (err) {
-            logging.error(err);
-            process.exit(1);
-        }
+    const options = program.opts();
+    let knexMigrator;
 
-        return knexMigrator.init({
-            skip: options.skip,
-            only: options.only
-        }).then(function () {
-            logging.info('Finished database init!');
+    try {
+        knexMigrator = new KnexMigrator({
+            knexMigratorFilePath: options.mgpath,
+            executedFromShell: true,
         });
-    })
-    .catch(function (err) {
+    } catch (err) {
+        logging.error(err);
+        process.exit(1);
+    }
+
+    await knexMigrator.init({
+        skip: options.skip,
+        only: options.only,
+    });
+    logging.info('Finished database init!');
+}
+
+main().catch(function (err) {
         logging.error(err);
         process.exit(1);
     });

--- a/bin/knex-migrator-migrate
+++ b/bin/knex-migrator-migrate
@@ -1,40 +1,44 @@
 #!/usr/bin/env node
 
-var program = require('commander').program;
-var utils = require('../lib/utils');
+const program = require('commander').program;
+const utils = require('../lib/utils');
 
-var logging = require('@tryghost/logging');
-var knexMigrator;
+const logging = require('@tryghost/logging');
 
-utils.getKnexMigrator({path: process.cwd()})
-    .then(function (KnexMigrator) {
-        program
-            .option('--v <item>')
-            .option('--only <item>')
-            .option('--mgpath <path>')
-            .option('--force')
-            .option('--init')
-            .parse(process.argv);
+async function main() {
+    const KnexMigrator = await utils.getKnexMigrator({path: process.cwd()});
 
-        var options = program.opts();
+    program
+        .option('--v <item>')
+        .option('--only <item>')
+        .option('--mgpath <path>')
+        .option('--force')
+        .option('--init')
+        .parse(process.argv);
 
-        try {
-            knexMigrator = new KnexMigrator({knexMigratorFilePath: options.mgpath, executedFromShell: true});
-        } catch (err) {
-            logging.error(err);
-            process.exit(1);
-        }
+    const options = program.opts();
+    let knexMigrator;
 
-        return knexMigrator.migrate({
-            version: options.v,
-            only: options.only,
-            force: options.force,
-            init: options.init
-        }).then(function () {
-            logging.info('Finished database migration!');
+    try {
+        knexMigrator = new KnexMigrator({
+            knexMigratorFilePath: options.mgpath,
+            executedFromShell: true,
         });
-    })
-    .catch(function (err) {
+    } catch (err) {
+        logging.error(err);
+        process.exit(1);
+    }
+
+    await knexMigrator.migrate({
+        version: options.v,
+        only: options.only,
+        force: options.force,
+        init: options.init,
+    });
+    logging.info('Finished database migration!');
+}
+
+main().catch(function (err) {
         logging.error(err);
         process.exit(1);
     });

--- a/bin/knex-migrator-reset
+++ b/bin/knex-migrator-reset
@@ -1,33 +1,36 @@
 #!/usr/bin/env node
 
-var program = require('commander').program;
-var utils = require('../lib/utils');
+const program = require('commander').program;
+const utils = require('../lib/utils');
 
-var logging = require('@tryghost/logging');
-var knexMigrator;
+const logging = require('@tryghost/logging');
 
-utils.getKnexMigrator({path: process.cwd()})
-    .then(function (KnexMigrator) {
-        program
-            .option('--mgpath <path>')
-            .option('--force')
-            .parse(process.argv);
+async function main() {
+    const KnexMigrator = await utils.getKnexMigrator({path: process.cwd()});
 
-        var options = program.opts();
+    program
+        .option('--mgpath <path>')
+        .option('--force')
+        .parse(process.argv);
 
-        try {
-            knexMigrator = new KnexMigrator({knexMigratorFilePath: options.mgpath, executedFromShell: true});
-        } catch (err) {
-            logging.error(err);
-            process.exit(1);
-        }
+    const options = program.opts();
+    let knexMigrator;
 
-        return knexMigrator.reset({force: options.force})
-            .then(function () {
-                logging.info('Finished database reset!');
-            });
-    })
-    .catch(function (err) {
+    try {
+        knexMigrator = new KnexMigrator({
+            knexMigratorFilePath: options.mgpath,
+            executedFromShell: true,
+        });
+    } catch (err) {
+        logging.error(err);
+        process.exit(1);
+    }
+
+    await knexMigrator.reset({force: options.force});
+    logging.info('Finished database reset!');
+}
+
+main().catch(function (err) {
         logging.error(err);
         process.exit(1);
     });

--- a/bin/knex-migrator-rollback
+++ b/bin/knex-migrator-rollback
@@ -4,31 +4,34 @@ const program = require('commander').program;
 const utils = require('../lib/utils');
 
 const logging = require('@tryghost/logging');
-let knexMigrator;
 
-utils.getKnexMigrator({path: process.cwd()})
-    .then(function (KnexMigrator) {
-        program
-            .option('--mgpath <path>')
-            .option('--force')
-            .option('--v <version>', 'The version to rollback to.')
-            .parse(process.argv);
+async function main() {
+    const KnexMigrator = await utils.getKnexMigrator({path: process.cwd()});
 
-        const options = program.opts();
+    program
+        .option('--mgpath <path>')
+        .option('--force')
+        .option('--v <version>', 'The version to rollback to.')
+        .parse(process.argv);
 
-        try {
-            knexMigrator = new KnexMigrator({knexMigratorFilePath: options.mgpath, executedFromShell: true});
-        } catch (err) {
-            logging.error(err);
-            process.exit(1);
-        }
+    const options = program.opts();
+    let knexMigrator;
 
-        return knexMigrator.rollback({force: options.force, version: options.v})
-            .then(function () {
-                logging.info('Rollback was successful.');
-            });
-    })
-    .catch(function (err) {
+    try {
+        knexMigrator = new KnexMigrator({
+            knexMigratorFilePath: options.mgpath,
+            executedFromShell: true,
+        });
+    } catch (err) {
+        logging.error(err);
+        process.exit(1);
+    }
+
+    await knexMigrator.rollback({force: options.force, version: options.v});
+    logging.info('Rollback was successful.');
+}
+
+main().catch(function (err) {
         logging.error(err.message);
 
         if (err.help) {

--- a/lib/database.js
+++ b/lib/database.js
@@ -6,6 +6,19 @@ const path = require('path'),
 const DatabaseInfo = require('@tryghost/database-info');
 const { sequence } = require('@tryghost/promise');
 
+function destroyConnection(connection) {
+    return new Promise(function (resolve, reject) {
+        connection.destroy(function (err) {
+            if (err) {
+                reject(err);
+                return;
+            }
+
+            resolve();
+        });
+    });
+}
+
 function loadKnex(options) {
     options = options || {};
 
@@ -77,8 +90,10 @@ exports.connect = function connect(options, connectionOptions) {
  * @param connection
  * @returns {Promise<R> | Promise<any> | Promise<T>}
  */
-exports.ensureConnectionWorks = (connection) => {
-    return connection.raw('SELECT 1+1 as RESULT;').catch((err) => {
+exports.ensureConnectionWorks = async function ensureConnectionWorks(connection) {
+    try {
+        await connection.raw('SELECT 1+1 as RESULT;');
+    } catch (err) {
         if (err.code === 'ENOTFOUND' || err.code === 'ETIMEDOUT' || err.code === 'EAI_AGAIN') {
             throw new errors.DatabaseError({
                 message: 'Invalid database host.',
@@ -92,7 +107,7 @@ exports.ensureConnectionWorks = (connection) => {
             help: 'Unknown database error',
             err: err,
         });
-    });
+    }
 };
 
 /**
@@ -134,19 +149,22 @@ exports.createMigrationsTable = async function createMigrationsTable(connection)
  * @param dbConfig
  * @returns {*}
  */
-exports.createDatabaseIfNotExist = function createDatabaseIfNotExist(dbConfig, connectionOptions) {
-    const name = dbConfig.connection.database,
-        charset = dbConfig.connection.charset || 'utf8mb4';
+exports.createDatabaseIfNotExist = async function createDatabaseIfNotExist(
+    dbConfig,
+    connectionOptions,
+) {
+    const name = dbConfig.connection.database;
+    const charset = dbConfig.connection.charset || 'utf8mb4';
 
     // @NOTE: Skip, because sqlite3 is a file based database.
     if (DatabaseInfo.isSQLiteConfig(dbConfig)) {
-        return Promise.resolve();
-    } else if (!DatabaseInfo.isMySQLConfig(dbConfig)) {
-        return Promise.reject(
-            new errors.KnexMigrateError({
-                message: 'Database is not supported.',
-            }),
-        );
+        return;
+    }
+
+    if (!DatabaseInfo.isMySQLConfig(dbConfig)) {
+        throw new errors.KnexMigrateError({
+            message: 'Database is not supported.',
+        });
     }
 
     const connection = exports.connect(
@@ -159,35 +177,24 @@ exports.createDatabaseIfNotExist = function createDatabaseIfNotExist(dbConfig, c
 
     debug('Create database', name);
 
-    return exports
-        .ensureConnectionWorks(connection)
-        .then(function () {
-            return connection.raw('CREATE DATABASE `' + name + '` CHARACTER SET ' + charset + ';');
-        })
-        .catch(function (err) {
-            // CASE: DB exists
-            if (err.errno === 1007) {
-                return Promise.resolve();
-            }
+    try {
+        await exports.ensureConnectionWorks(connection);
+        await connection.raw('CREATE DATABASE `' + name + '` CHARACTER SET ' + charset + ';');
+    } catch (err) {
+        // CASE: DB exists
+        if (err.errno === 1007) {
+            return;
+        }
 
-            throw new errors.DatabaseError({
-                message: err.message,
-                err: err,
-                code: 'DATABASE_CREATION_FAILED',
-            });
-        })
-        .finally(function () {
-            return new Promise(function (resolve, reject) {
-                connection.destroy(function (err) {
-                    if (err) {
-                        return reject(err);
-                    }
-
-                    debug('Destroy connection');
-                    resolve();
-                });
-            });
+        throw new errors.DatabaseError({
+            message: err.message,
+            err: err,
+            code: 'DATABASE_CREATION_FAILED',
         });
+    } finally {
+        await destroyConnection(connection);
+        debug('Destroy connection');
+    }
 };
 
 /**
@@ -196,30 +203,32 @@ exports.createDatabaseIfNotExist = function createDatabaseIfNotExist(dbConfig, c
  * @param options
  * @returns {*}
  */
-exports.drop = function drop(options) {
+exports.drop = async function drop(options) {
     options = options || {};
 
-    const connection = options.connection,
-        dbConfig = options.dbConfig;
+    const connection = options.connection;
+    const dbConfig = options.dbConfig;
 
     if (DatabaseInfo.isMySQL(connection)) {
         debug('Drop database: ' + dbConfig.connection.database);
 
-        return connection
-            .raw('DROP DATABASE `' + dbConfig.connection.database + '`;')
-            .catch(function (err) {
-                // CASE: database does not exist, skip
-                if (err.errno === 1049) {
-                    return Promise.resolve();
-                }
+        try {
+            await connection.raw('DROP DATABASE `' + dbConfig.connection.database + '`;');
+        } catch (err) {
+            // CASE: database does not exist, skip
+            if (err.errno === 1049) {
+                return;
+            }
 
-                return Promise.reject(
-                    new errors.KnexMigrateError({
-                        err: err,
-                    }),
-                );
+            throw new errors.KnexMigrateError({
+                err: err,
             });
-    } else if (DatabaseInfo.isSQLite(connection)) {
+        }
+
+        return;
+    }
+
+    if (DatabaseInfo.isSQLite(connection)) {
         // @NOTE: sqlite3 does not support "DROP DATABASE". We have to drop each table instead.
         // @NOTE: We cannot just remove the sqlite3 file, because any database connection will get invalid.
         // @NOTE: better-sqlite3 enforces foreign key constraints, so dropping a parent table before
@@ -228,45 +237,45 @@ exports.drop = function drop(options) {
         // across the drops. The legacy sqlite3 driver does not enforce these, so we leave it untouched.
         const isBetterSqlite = connection.client.config.client === 'better-sqlite3';
 
-        return (isBetterSqlite ? connection.raw('PRAGMA foreign_keys = OFF;') : Promise.resolve())
-            .then(function () {
-                return connection.raw(`SELECT name FROM sqlite_master WHERE type='table';`);
-            })
-            .then(function (tables) {
-                return sequence(
-                    tables.map((table) => () => {
-                        if (table.name === 'sqlite_sequence') {
-                            debug('Skip drop table: ' + table.name);
-                            return Promise.resolve();
-                        }
+        try {
+            if (isBetterSqlite) {
+                await connection.raw('PRAGMA foreign_keys = OFF;');
+            }
 
-                        debug('Drop table: ' + table.name);
-                        return connection.schema.dropTableIfExists(table.name);
-                    }),
-                );
-            })
-            .catch(function (err) {
-                // CASE: database file was never initialised
-                if (err.errno === 10) {
-                    return Promise.resolve();
-                }
+            const tables = await connection.raw(
+                `SELECT name FROM sqlite_master WHERE type='table';`,
+            );
 
-                return Promise.reject(
-                    new errors.KnexMigrateError({
-                        err: err,
-                    }),
-                );
-            })
-            .finally(function () {
-                if (isBetterSqlite) {
-                    return connection.raw('PRAGMA foreign_keys = ON;');
-                }
+            await sequence(
+                tables.map((table) => async () => {
+                    if (table.name === 'sqlite_sequence') {
+                        debug('Skip drop table: ' + table.name);
+                        return;
+                    }
+
+                    debug('Drop table: ' + table.name);
+                    await connection.schema.dropTableIfExists(table.name);
+                }),
+            );
+        } catch (err) {
+            // CASE: database file was never initialised
+            if (err.errno === 10) {
+                return;
+            }
+
+            throw new errors.KnexMigrateError({
+                err: err,
             });
-    } else {
-        return Promise.reject(
-            new errors.KnexMigrateError({
-                message: 'Database client not supported: ' + dbConfig.client,
-            }),
-        );
+        } finally {
+            if (isBetterSqlite) {
+                await connection.raw('PRAGMA foreign_keys = ON;');
+            }
+        }
+
+        return;
     }
+
+    throw new errors.KnexMigrateError({
+        message: 'Database client not supported: ' + dbConfig.client,
+    });
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -486,78 +486,68 @@ KnexMigrator.prototype.migrate = async function migrate(options) {
  * @param {Object} options - Custom options the user can pass in (force)
  * @returns {*}
  */
-KnexMigrator.prototype.reset = function reset(options) {
+KnexMigrator.prototype.reset = async function reset(options) {
     options = options || {};
 
-    let self = this;
-    let force = options.force;
+    const force = options.force;
 
     this.connection = database.connect(this.dbConfig, { knexModulePath: this.knexModulePath });
 
     // CASE: ignore lock completely and drop the db
     if (force) {
-        return database
-            .drop({
-                connection: self.connection,
-                dbConfig: self.dbConfig,
-            })
-            .catch(function onRestError(err) {
-                // Database does not exist. MySql.
-                if (err.errno === 1049) {
-                    return Promise.resolve();
-                }
-
-                throw err;
-            })
-            .finally(function () {
-                debug('Destroy connection');
-                return self.connection.destroy().then(function () {
-                    debug('Destroyed connection');
-                });
+        try {
+            await database.drop({
+                connection: this.connection,
+                dbConfig: this.dbConfig,
             });
+        } catch (err) {
+            // Database does not exist. MySql.
+            if (err.errno === 1049) {
+                return;
+            }
+
+            throw err;
+        } finally {
+            debug('Destroy connection');
+            await this.connection.destroy();
+            debug('Destroyed connection');
+        }
+
+        return;
     }
 
-    return database
-        .ensureConnectionWorks(this.connection)
-        .then(function () {
-            return migrations.run(self.connection);
-        })
-        .then(function () {
-            return locking.lock(self.connection);
-        })
-        .then(function () {
-            return database.drop({
-                connection: self.connection,
-                dbConfig: self.dbConfig,
-            });
-        })
-        .catch(function onRestError(err) {
-            if (err instanceof errors.MigrationsAreLockedError) {
-                throw err;
-            }
-
-            // CASE: ETIMEDOUT, ENOTFOUND
-            if (err instanceof errors.DatabaseError) {
-                throw err;
-            }
-
-            debug('Reset error: ' + err.message);
-
-            // CASE: Database does not exist. For MySql.
-            if (err.errno === 1049) {
-                return Promise.resolve();
-            }
-
-            return locking.unlock(self.connection).then(function () {
-                throw err;
-            });
-        })
-        .finally(function () {
-            debug('Destroy connection');
-            return self.connection.destroy().then(function () {
-                debug('Destroyed connection');
-            });
+    try {
+        await database.ensureConnectionWorks(this.connection);
+        await migrations.run(this.connection);
+        await locking.lock(this.connection);
+        await database.drop({
+            connection: this.connection,
+            dbConfig: this.dbConfig,
         });
+    } catch (err) {
+        if (err instanceof errors.MigrationsAreLockedError) {
+            throw err;
+        }
+
+        // CASE: ETIMEDOUT, ENOTFOUND
+        if (err instanceof errors.DatabaseError) {
+            throw err;
+        }
+
+        debug('Reset error: ' + err.message);
+
+        // CASE: Database does not exist. For MySql.
+        if (err.errno === 1049) {
+            return;
+        }
+
+        await locking.unlock(this.connection);
+        throw err;
+    } finally {
+        debug('Destroy connection');
+        await this.connection.destroy();
+        debug('Destroyed connection');
+    }
 };
 
 /**
@@ -582,70 +572,58 @@ KnexMigrator.prototype.reset = function reset(options) {
  *
  * @returns {Promise<any>}
  */
-KnexMigrator.prototype.isDatabaseOK = function isDatabaseOK() {
-    let self = this;
+KnexMigrator.prototype.isDatabaseOK = async function isDatabaseOK() {
     this.connection = database.connect(this.dbConfig, { knexModulePath: this.knexModulePath });
 
-    return database
-        .ensureConnectionWorks(this.connection)
-        .then(function () {
-            return migrations.run(self.connection);
-        })
-        .then(function () {
-            return locking.isLocked(self.connection);
-        })
-        .then(function () {
-            return self._integrityCheck();
-        })
-        .then(function (result) {
-            // CASE: if an init script was removed, the health check will be positive (see #48)
-            if (result.init && result.init.expected > result.init.actual) {
+    try {
+        await database.ensureConnectionWorks(this.connection);
+        await migrations.run(this.connection);
+        await locking.isLocked(this.connection);
+
+        const result = await this._integrityCheck();
+        // CASE: if an init script was removed, the health check will be positive (see #48)
+        if (result.init && result.init.expected > result.init.actual) {
+            throw new errors.DatabaseIsNotOkError({
+                message: 'Please run `pnpm knex-migrator init`',
+                code: 'DB_NOT_INITIALISED',
+            });
+        }
+
+        _.each(_.omit(result, 'init'), function (value) {
+            // CASE: there are more migrations expected than have been run, database needs to be migrated
+            if (value.expected > value.actual) {
                 throw new errors.DatabaseIsNotOkError({
-                    message: 'Please run `pnpm knex-migrator init`',
-                    code: 'DB_NOT_INITIALISED',
+                    message: 'Migrations are missing. Please run `pnpm knex-migrator migrate`.',
+                    code: 'DB_NEEDS_MIGRATION',
+                    help: `Expected: ${value.expected} items in migrations table, found: ${value.actual}`,
+                });
+                // CASE: there are more actual migrations than expected, something has gone wrong :(
+            } else if (value.expected < value.actual) {
+                throw new errors.DatabaseIsNotOkError({
+                    message:
+                        'Detected more items in the migrations table than expected. Please manually inspect the migrations table.',
+                    code: 'MIGRATION_STATE_ERROR',
+                    help: `Expected: ${value.expected} items in migrations table, found: ${value.actual}`,
                 });
             }
-
-            _.each(_.omit(result, 'init'), function (value) {
-                // CASE: there are more migrations expected than have been run, database needs to be migrated
-                if (value.expected > value.actual) {
-                    throw new errors.DatabaseIsNotOkError({
-                        message: 'Migrations are missing. Please run `pnpm knex-migrator migrate`.',
-                        code: 'DB_NEEDS_MIGRATION',
-                        help: `Expected: ${value.expected} items in migrations table, found: ${value.actual}`,
-                    });
-                    // CASE: there are more actual migrations than expected, something has gone wrong :(
-                } else if (value.expected < value.actual) {
-                    throw new errors.DatabaseIsNotOkError({
-                        message:
-                            'Detected more items in the migrations table than expected. Please manually inspect the migrations table.',
-                        code: 'MIGRATION_STATE_ERROR',
-                        help: `Expected: ${value.expected} items in migrations table, found: ${value.actual}`,
-                    });
-                }
-            });
-        })
-        .catch(function (err) {
-            // CASE: database does not exist
-            if (err.errno === 1049) {
-                throw new errors.DatabaseIsNotOkError({
-                    message: 'Please run `pnpm knex-migrator init`',
-                    code: 'DB_NOT_INITIALISED',
-                });
-            }
-
-            throw err;
-        })
-        .finally(function () {
-            if (!self.connection) {
-                return;
-            }
-
-            debug('Destroy connection');
-            return self.connection.destroy().then(function () {
-                debug('Destroyed connection');
-            });
         });
+    } catch (err) {
+        // CASE: database does not exist
+        if (err.errno === 1049) {
+            throw new errors.DatabaseIsNotOkError({
+                message: 'Please run `pnpm knex-migrator init`',
+                code: 'DB_NOT_INITIALISED',
+            });
+        }
+
+        throw err;
+    } finally {
+        if (this.connection) {
+            debug('Destroy connection');
+            await this.connection.destroy();
+            debug('Destroyed connection');
+        }
+    }
 };
 
 /**
@@ -666,139 +644,118 @@ KnexMigrator.prototype.isDatabaseOK = function isDatabaseOK() {
  * @param {Object} options - Custom options the user can pass in (force, version, v, disableHooks)
  * @returns {Promise<any>}
  */
-KnexMigrator.prototype.rollback = function rollback(options) {
+KnexMigrator.prototype.rollback = async function rollback(options) {
     options = options || {};
 
-    let self = this;
-    let force = options.force;
-    let version = options.version || options.v;
-    let disableHooks = options.disableHooks;
+    const force = options.force;
+    const version = options.version || options.v;
+    const disableHooks = options.disableHooks;
     let hooks = {};
 
     this.connection = database.connect(this.dbConfig, { knexModulePath: this.knexModulePath });
 
-    const helper = function helper() {
-        return new Promise(function (resolve, reject) {
-            try {
-                if (!disableHooks) {
-                    // @TODO: load init or migrate hooks
-                    hooks = require(path.join(self.migrationPath, '/hooks/init'));
-                }
-            } catch (err) {
-                debug('Hook Error: ' + err.message);
-                debug('No hooks found, no problem.');
+    const helper = async () => {
+        try {
+            if (!disableHooks) {
+                // @TODO: load init or migrate hooks
+                hooks = require(path.join(this.migrationPath, '/hooks/init'));
             }
+        } catch (err) {
+            debug('Hook Error: ' + err.message);
+            debug('No hooks found, no problem.');
+        }
 
-            if (hooks.before) {
-                return hooks
-                    .before({
-                        connection: self.connection,
-                    })
-                    .then(resolve)
-                    .catch(reject);
-            }
-
-            resolve();
-        })
-            .then(function () {
-                let whereQuery = {};
-
-                // CASE 1: rollback to specific version (query all and filter out)
-                // CASE 2: rollback current version you are on
-                if (version) {
-                    debug(`Rollback to specific version: ${version}`);
-                    whereQuery = {};
-                } else {
-                    whereQuery = {
-                        currentVersion: self.currentVersion,
-                    };
-                }
-
-                return self
-                    .connection('migrations')
-                    .where(whereQuery)
-                    .then(function (values) {
-                        if (!values.length) {
-                            throw new errors.IncorrectUsageError({
-                                message: 'No migrations available to rollback.',
-                            });
-                        }
-
-                        // CASE: filter out all versions which are smaller than the version we want to rollback to
-                        if (version) {
-                            values = _.filter(values, function (value) {
-                                return utils.isGreaterThanVersion({
-                                    greaterVersion: value.version,
-                                    smallerVersion: version,
-                                });
-                            });
-                        }
-
-                        // @NOTE: we never ever rollback init scripts for now.
-                        //       this can be very dangerous, because it removes tables
-                        // @EXCEPTION: you run init scripts and they fail
-                        values = _.filter(values, function (value) {
-                            return value.version !== 'init';
-                        });
-
-                        values.reverse();
-                        return sequence(
-                            values.map((value) => () => {
-                                return self._rollback({
-                                    version: value.version,
-                                    onlyTasks: [value.name],
-                                });
-                            }),
-                        );
-                    });
-            })
-            .then(function () {
-                if (hooks.shutdown) {
-                    return hooks.shutdown({
-                        executedFromShell: self.executedFromShell,
-                    });
-                }
+        if (hooks.before) {
+            await hooks.before({
+                connection: this.connection,
             });
+        }
+
+        let whereQuery = {};
+
+        // CASE 1: rollback to specific version (query all and filter out)
+        // CASE 2: rollback current version you are on
+        if (version) {
+            debug(`Rollback to specific version: ${version}`);
+            whereQuery = {};
+        } else {
+            whereQuery = {
+                currentVersion: this.currentVersion,
+            };
+        }
+
+        let values = await this.connection('migrations').where(whereQuery);
+
+        if (!values.length) {
+            throw new errors.IncorrectUsageError({
+                message: 'No migrations available to rollback.',
+            });
+        }
+
+        // CASE: filter out all versions which are smaller than the version we want to rollback to
+        if (version) {
+            values = _.filter(values, (value) => {
+                return utils.isGreaterThanVersion({
+                    greaterVersion: value.version,
+                    smallerVersion: version,
+                });
+            });
+        }
+
+        // @NOTE: we never ever rollback init scripts for now.
+        //       this can be very dangerous, because it removes tables
+        // @EXCEPTION: you run init scripts and they fail
+        values = _.filter(values, (value) => {
+            return value.version !== 'init';
+        });
+
+        values.reverse();
+        await sequence(
+            values.map((value) => () => {
+                return this._rollback({
+                    version: value.version,
+                    onlyTasks: [value.name],
+                });
+            }),
+        );
+
+        if (hooks.shutdown) {
+            await hooks.shutdown({
+                executedFromShell: this.executedFromShell,
+            });
+        }
     };
 
-    return database
-        .ensureConnectionWorks(this.connection)
-        .then(function () {
-            return migrations.run(self.connection);
-        })
-        .then(function () {
-            return locking.isLocked(self.connection);
-        })
-        .then(function () {
-            // CASE: db is not locked, force
-            if (force) {
-                return helper();
-            }
+    try {
+        await database.ensureConnectionWorks(this.connection);
+        await migrations.run(this.connection);
+        await locking.isLocked(this.connection);
 
-            throw new errors.IncorrectUsageError({
-                message: 'Rollback did not happen.',
-                help: 'Use --force if you want to force a rollback. By default, rollbacks are only allowed if your database is locked.',
-            });
-        })
-        .catch(function (err) {
-            if (err instanceof errors.MigrationsAreLockedError) {
-                return helper().then(function () {
-                    return locking.unlock(self.connection);
-                });
-            }
+        // CASE: db is not locked, force
+        if (force) {
+            await helper();
+            return;
+        }
 
-            throw err;
-        })
-        .finally(function () {
-            if (!self.connection) {
-                return;
-            }
-
-            debug('Destroy connection');
-            return self.connection.destroy().then(function () {
-                debug('Destroyed connection');
-            });
+        throw new errors.IncorrectUsageError({
+            message: 'Rollback did not happen.',
+            help: 'Use --force if you want to force a rollback. By default, rollbacks are only allowed if your database is locked.',
         });
+    } catch (err) {
+        if (err instanceof errors.MigrationsAreLockedError) {
+            await helper();
+            await locking.unlock(this.connection);
+            return;
+        }
+
+        throw err;
+    } finally {
+        if (this.connection) {
+            debug('Destroy connection');
+            await this.connection.destroy();
+            debug('Destroyed connection');
+        }
+    }
 };
 
 // @TODO: All of these functions below are helper functions. Source them out as part of https://github.com/TryGhost/knex-migrator/issues/95.
@@ -1104,21 +1061,20 @@ KnexMigrator.prototype._migrateTo = function _migrateTo(options) {
  * @returns {*}
  * @private
  */
-KnexMigrator.prototype._beforeEach = function _beforeEach(options) {
+KnexMigrator.prototype._beforeEach = async function _beforeEach(options) {
     options = options || {};
 
-    let task = options.task,
-        version = options.version;
+    const task = options.task;
+    const version = options.version;
 
-    return this.connection('migrations').then(function (migrations) {
-        if (!migrations.length) {
-            return;
-        }
+    const migrations = await this.connection('migrations');
+    if (!migrations.length) {
+        return;
+    }
 
-        if (_.find(migrations, { name: task, version: version })) {
-            throw new errors.MigrationExistsError();
-        }
-    });
+    if (_.find(migrations, { name: task, version: version })) {
+        throw new errors.MigrationExistsError();
+    }
 };
 
 /**
@@ -1133,14 +1089,13 @@ KnexMigrator.prototype._beforeEach = function _beforeEach(options) {
 KnexMigrator.prototype._afterEach = function _afterEach(options) {
     options = options || {};
 
-    let self = this;
-    let task = options.task;
-    let version = options.version;
+    const task = options.task;
+    const version = options.version;
 
     return this.connection('migrations').insert({
         name: task.name,
         version: version,
-        currentVersion: self.currentVersion,
+        currentVersion: this.currentVersion,
     });
 };
 

--- a/lib/locking.js
+++ b/lib/locking.js
@@ -8,45 +8,45 @@ const database = require('./database');
  * @TODO Locks in Sqlite won't work, because Sqlite doesn't offer read locks (https://github.com/TryGhost/knex-migrator/issues/87)
  * @returns {*}
  */
-module.exports.lock = function (connection) {
+module.exports.lock = function lock(connection) {
     debug('Lock.');
 
-    return database.createTransaction(connection, function (transacting) {
-        return transacting('migrations_lock')
-            .where({
-                lock_key: 'km01',
-            })
-            .forUpdate()
-            .then(function (data) {
-                if (!data || !data.length || data[0].locked) {
-                    throw new errors.MigrationsAreLockedError({
-                        message:
-                            'Migrations are running at the moment. Please wait that the lock get`s released.',
-                        context:
-                            'Either the release was never released because of a e.g. died process or a parallel process is migrating at the moment.',
-                        help: "If your database looks okay, you can manually release the lock by running `UPDATE migrations_lock set locked=0 where lock_key='km01';`.",
-                    });
-                }
+    return database.createTransaction(connection, async function (transacting) {
+        try {
+            const data = await transacting('migrations_lock')
+                .where({
+                    lock_key: 'km01',
+                })
+                .forUpdate();
 
-                return (transacting || connection)('migrations_lock')
-                    .where({
-                        lock_key: 'km01',
-                    })
-                    .update({
-                        locked: 1,
-                        acquired_at: moment().format('YYYY-MM-DD HH:mm:ss'),
-                    });
-            })
-            .catch(function (err) {
-                if (errors.utils.isGhostError(err)) {
-                    throw err;
-                }
-
-                throw new errors.LockError({
-                    message: 'Error while acquire the migration lock.',
-                    err: err,
+            if (!data || !data.length || data[0].locked) {
+                throw new errors.MigrationsAreLockedError({
+                    message:
+                        'Migrations are running at the moment. Please wait that the lock get`s released.',
+                    context:
+                        'Either the release was never released because of a e.g. died process or a parallel process is migrating at the moment.',
+                    help: "If your database looks okay, you can manually release the lock by running `UPDATE migrations_lock set locked=0 where lock_key='km01';`.",
                 });
+            }
+
+            return (transacting || connection)('migrations_lock')
+                .where({
+                    lock_key: 'km01',
+                })
+                .update({
+                    locked: 1,
+                    acquired_at: moment().format('YYYY-MM-DD HH:mm:ss'),
+                });
+        } catch (err) {
+            if (errors.utils.isGhostError(err)) {
+                throw err;
+            }
+
+            throw new errors.LockError({
+                message: 'Error while acquire the migration lock.',
+                err: err,
             });
+        }
     });
 };
 
@@ -54,22 +54,19 @@ module.exports.lock = function (connection) {
  * @description Private helper to determine whether the database is locked or not.
  * @returns {boolean}
  */
-module.exports.isLocked = function (connection) {
-    return connection('migrations_lock')
-        .where({
-            lock_key: 'km01',
-        })
-        .then(function (data) {
-            if (!data || !data.length || data[0].locked) {
-                throw new errors.MigrationsAreLockedError({
-                    message:
-                        'Migration lock was never released or currently a migration is running.',
-                    help: 'If you are sure no migration is running, check your data and if your database is in a broken state, you could run `pnpm knex-migrator rollback`.',
-                });
-            }
+module.exports.isLocked = async function isLocked(connection) {
+    const data = await connection('migrations_lock').where({
+        lock_key: 'km01',
+    });
 
-            return false;
+    if (!data || !data.length || data[0].locked) {
+        throw new errors.MigrationsAreLockedError({
+            message: 'Migration lock was never released or currently a migration is running.',
+            help: 'If you are sure no migration is running, check your data and if your database is in a broken state, you could run `pnpm knex-migrator rollback`.',
         });
+    }
+
+    return false;
 };
 
 /**
@@ -77,40 +74,40 @@ module.exports.isLocked = function (connection) {
  * @TODO Locks in Sqlite won't work, because Sqlite doesn't offer read locks (https://github.com/TryGhost/knex-migrator/issues/87)
  * @returns {*}
  */
-module.exports.unlock = function (connection) {
+module.exports.unlock = function unlock(connection) {
     debug('Unlock.');
 
-    return database.createTransaction(connection, function (transacting) {
-        return transacting('migrations_lock')
-            .where({
-                lock_key: 'km01',
-            })
-            .forUpdate()
-            .then(function (data) {
-                if (!data || !data.length || !data[0].locked) {
-                    throw new errors.MigrationsAreLockedError({
-                        message: 'Migration lock was already released?.',
-                    });
-                }
+    return database.createTransaction(connection, async function (transacting) {
+        try {
+            const data = await transacting('migrations_lock')
+                .where({
+                    lock_key: 'km01',
+                })
+                .forUpdate();
 
-                return transacting('migrations_lock')
-                    .where({
-                        lock_key: 'km01',
-                    })
-                    .update({
-                        locked: 0,
-                        released_at: moment().format('YYYY-MM-DD HH:mm:ss'),
-                    });
-            })
-            .catch(function (err) {
-                if (errors.utils.isGhostError(err)) {
-                    throw err;
-                }
-
-                throw new errors.UnlockError({
-                    message: 'Error while releasing the migration lock.',
-                    err: err,
+            if (!data || !data.length || !data[0].locked) {
+                throw new errors.MigrationsAreLockedError({
+                    message: 'Migration lock was already released?.',
                 });
+            }
+
+            return transacting('migrations_lock')
+                .where({
+                    lock_key: 'km01',
+                })
+                .update({
+                    locked: 0,
+                    released_at: moment().format('YYYY-MM-DD HH:mm:ss'),
+                });
+        } catch (err) {
+            if (errors.utils.isGhostError(err)) {
+                throw err;
+            }
+
+            throw new errors.UnlockError({
+                message: 'Error while releasing the migration lock.',
+                err: err,
             });
+        }
     });
 };

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,10 +1,9 @@
-const path = require('path'),
-    _ = require('lodash'),
-    fs = require('fs'),
-    compareVer = require('compare-ver'),
-    resolve = require('util').promisify(require('resolve')),
-    debug = require('debug')('knex-migrator:utils'),
-    errors = require('./errors');
+const path = require('path');
+const fs = require('fs');
+const compareVer = require('compare-ver');
+const resolve = require('util').promisify(require('resolve'));
+const debug = require('debug')('knex-migrator:utils');
+const errors = require('./errors');
 
 /**
  * @description This helper function offers two ways of loading the knex-migrator configuration.
@@ -70,7 +69,7 @@ exports.listFiles = function listFiles(absolutePath) {
         });
     }
 
-    files = files.filter(function (file) {
+    files = files.filter((file) => {
         // CASE: ignore dot files
         return !file.match(/^\./);
     });
@@ -87,20 +86,17 @@ exports.listFiles = function listFiles(absolutePath) {
  * @returns {Array}
  */
 exports.readTasks = function readTasks(absolutePath) {
-    let tasks = [];
-
     const files = exports.listFiles(absolutePath);
-
-    _.each(files, function (file) {
-        let executeFn = require(path.join(absolutePath, file));
+    const tasks = files.map((file) => {
+        const executeFn = require(path.join(absolutePath, file));
 
         try {
-            tasks.push({
+            return {
                 up: executeFn.up,
                 down: executeFn.down,
                 config: executeFn.config,
                 name: file,
-            });
+            };
         } catch (err) {
             debug(err.message);
 
@@ -123,8 +119,8 @@ exports.readTasks = function readTasks(absolutePath) {
  * @returns {*}
  */
 exports.readVersionFolders = function readFolders(absolutePath) {
-    let folders = [],
-        toReturn = [];
+    let folders = [];
+    const toReturn = [];
 
     try {
         folders = fs.readdirSync(absolutePath);
@@ -177,16 +173,15 @@ exports.readVersionFolders = function readFolders(absolutePath) {
 /**
  * @description Auto detect local installation to avoid version incompatible behaviour
  */
-exports.getKnexMigrator = function getKnexMigrator(options) {
+exports.getKnexMigrator = async function getKnexMigrator(options) {
     options = options || {};
 
-    return resolve('knex-migrator', { basedir: options.path })
-        .then(function (localCLIPath) {
-            return require(localCLIPath);
-        })
-        .catch(function () {
-            return require('./');
-        });
+    try {
+        const localCLIPath = await resolve('knex-migrator', { basedir: options.path });
+        return require(localCLIPath);
+    } catch {
+        return require('./');
+    }
 };
 
 /**

--- a/migrations/add-primary-key-to-lock-table.js
+++ b/migrations/add-primary-key-to-lock-table.js
@@ -4,56 +4,52 @@ const DatabaseInfo = require('@tryghost/database-info');
 /**
  * Checks if primary key index exists in a table over the given columns.
  */
-function hasPrimaryKeySQLite(tableName, knex) {
+async function hasPrimaryKeySQLite(tableName, knex) {
     if (!DatabaseInfo.isSQLite(knex)) {
         throw new Error('Must use hasPrimaryKeySQLite on an SQLite3 database');
     }
 
-    return knex.raw(`PRAGMA index_list('${tableName}');`).then((rawConstraints) => {
-        const tablePrimaryKey = rawConstraints.find((c) => c.origin === 'pk');
-        return tablePrimaryKey;
-    });
+    const rawConstraints = await knex.raw(`PRAGMA index_list('${tableName}');`);
+    return rawConstraints.find((constraint) => constraint.origin === 'pk');
 }
 
 /**
  * Adds an primary key index to a table over the given columns.
  */
-function addPrimaryKey(tableName, columns, knex) {
+async function addPrimaryKey(tableName, columns, knex) {
     if (DatabaseInfo.isSQLite(knex)) {
-        return hasPrimaryKeySQLite(tableName, knex).then((primaryKeyExists) => {
-            if (primaryKeyExists) {
-                debug(
-                    `Primary key constraint for: ${columns} already exists for table: ${tableName}`,
-                );
-                return;
-            }
+        const primaryKeyExists = await hasPrimaryKeySQLite(tableName, knex);
 
-            return knex.schema.table(tableName, function (table) {
-                table.primary(columns);
-            });
+        if (primaryKeyExists) {
+            debug(`Primary key constraint for: ${columns} already exists for table: ${tableName}`);
+            return;
+        }
+
+        await knex.schema.table(tableName, function (table) {
+            table.primary(columns);
         });
+        return;
     }
 
-    return knex.schema
-        .table(tableName, function (table) {
+    try {
+        await knex.schema.table(tableName, function (table) {
             table.primary(columns);
-        })
-        .catch((err) => {
-            if (err.code === 'ER_MULTIPLE_PRI_KEY') {
-                debug(
-                    `Primary key constraint for: ${columns} already exists for table: ${tableName}`,
-                );
-                return;
-            }
-            throw err;
         });
+    } catch (err) {
+        if (err.code === 'ER_MULTIPLE_PRI_KEY') {
+            debug(`Primary key constraint for: ${columns} already exists for table: ${tableName}`);
+            return;
+        }
+
+        throw err;
+    }
 }
 
 /**
  * @description Private helper to create add a primary key to the migration lock table. The helper is called as part of `runDatabaseUpgrades`.
  * @returns {*}
  */
-module.exports.up = function (connection) {
+module.exports.up = function up(connection) {
     debug('Add primary key to the lock table.');
 
     return addPrimaryKey('migrations_lock', 'lock_key', connection);

--- a/migrations/field-length.js
+++ b/migrations/field-length.js
@@ -4,20 +4,20 @@ const debug = require('debug')('knex-migrator:field-length');
  * @description Private helper to migrate the migrations table. It will add missing constraints to existing fields.
  * @returns {*}
  */
-module.exports.up = function (connection) {
+module.exports.up = async function up(connection) {
     debug('Ensure Field Length.');
 
-    return connection.schema.hasTable('migrations').then(function (exists) {
-        if (exists) {
-            return connection.schema
-                .alterTable('migrations', function (table) {
-                    table.string('name', 120).nullable(false).alter();
-                    table.string('version', 70).nullable(false).alter();
-                })
-                .catch(function () {
-                    // ignore for now, it's not a urgent, required change
-                    return Promise.resolve();
-                });
-        }
-    });
+    const exists = await connection.schema.hasTable('migrations');
+    if (!exists) {
+        return;
+    }
+
+    try {
+        await connection.schema.alterTable('migrations', function (table) {
+            table.string('name', 120).nullable(false).alter();
+            table.string('version', 70).nullable(false).alter();
+        });
+    } catch {
+        // ignore for now, it's not a urgent, required change
+    }
 };

--- a/migrations/index.js
+++ b/migrations/index.js
@@ -8,10 +8,9 @@ const addPKToLockTable = require('./add-primary-key-to-lock-table');
  *
  * You can use this helper to execute more database migrations. It get's called as soon as you hit any knex-migrator command.
  */
-module.exports.run = function (connection) {
-    return Promise.resolve()
-        .then(() => lockTable.up(connection))
-        .then(() => fieldLength.up(connection))
-        .then(() => useIndex.up(connection))
-        .then(() => addPKToLockTable.up(connection));
+module.exports.run = async function run(connection) {
+    await lockTable.up(connection);
+    await fieldLength.up(connection);
+    await useIndex.up(connection);
+    await addPKToLockTable.up(connection);
 };

--- a/migrations/lock-table.js
+++ b/migrations/lock-table.js
@@ -5,40 +5,37 @@ const errors = require('../lib/errors');
  * @description Private helper to create the migration lock table. The helper is called as part of `runDatabaseUpgrades`.
  * @returns {*}
  */
-module.exports.up = function (connection) {
+module.exports.up = async function up(connection) {
     debug('Ensure Lock Table.');
 
-    return connection.schema.hasTable('migrations_lock').then(function (table) {
-        if (table) {
-            return;
+    const hasTable = await connection.schema.hasTable('migrations_lock');
+    if (hasTable) {
+        return;
+    }
+
+    try {
+        await connection.schema.createTable('migrations_lock', function (table) {
+            table.string('lock_key', 191).nullable(false).primary();
+            table.boolean('locked').default(0);
+            table.dateTime('acquired_at').nullable();
+            table.dateTime('released_at').nullable();
+        });
+        await connection('migrations_lock').insert({
+            lock_key: 'km01',
+            locked: 0,
+        });
+    } catch (err) {
+        // CASE: sqlite db is locked (e.g. concurrent migrations are running)
+        if (err.errno === 5) {
+            throw new errors.MigrationsAreLockedError({
+                message:
+                    'Migrations are running at the moment. Please wait that the lock get`s released.',
+                context:
+                    'Either the release was never released because of a e.g. died process or a parallel process is migrating at the moment.',
+                help: "If you know what you are doing, you can manually release the lock by running `UPDATE migrations_lock set locked=0 where lock_key='km01';`.",
+            });
         }
 
-        return connection.schema
-            .createTable('migrations_lock', function (table) {
-                table.string('lock_key', 191).nullable(false).primary();
-                table.boolean('locked').default(0);
-                table.dateTime('acquired_at').nullable();
-                table.dateTime('released_at').nullable();
-            })
-            .then(function () {
-                return connection('migrations_lock').insert({
-                    lock_key: 'km01',
-                    locked: 0,
-                });
-            })
-            .catch(function (err) {
-                // CASE: sqlite db is locked (e.g. concurrent migrations are running)
-                if (err.errno === 5) {
-                    throw new errors.MigrationsAreLockedError({
-                        message:
-                            'Migrations are running at the moment. Please wait that the lock get`s released.',
-                        context:
-                            'Either the release was never released because of a e.g. died process or a parallel process is migrating at the moment.',
-                        help: "If you know what you are doing, you can manually release the lock by running `UPDATE migrations_lock set locked=0 where lock_key='km01';`.",
-                    });
-                }
-
-                throw err;
-            });
-    });
+        throw err;
+    }
 };

--- a/migrations/use-index.js
+++ b/migrations/use-index.js
@@ -4,21 +4,21 @@ const debug = require('debug')('knex-migrator:use-index');
  * @description Private helper to migrate the migrations table. It will add missing indexes to existing fields.
  * @returns {*}
  */
-module.exports.up = function (connection) {
+module.exports.up = async function up(connection) {
     debug('Ensure Unique Index.');
 
-    return connection.schema.hasTable('migrations').then(function (exists) {
-        if (exists) {
-            return connection.schema
-                .alterTable('migrations', function (table) {
-                    table.unique(['name', 'version']);
-                })
-                .catch(function () {
-                    // @NOTE: ignore for now, it's not a urgent, required change
-                    // e.g. index exists already (1061,1)
-                    // e.g. can't index because of already existing duplicates
-                    return Promise.resolve();
-                });
-        }
-    });
+    const exists = await connection.schema.hasTable('migrations');
+    if (!exists) {
+        return;
+    }
+
+    try {
+        await connection.schema.alterTable('migrations', function (table) {
+            table.unique(['name', 'version']);
+        });
+    } catch {
+        // @NOTE: ignore for now, it's not a urgent, required change
+        // e.g. index exists already (1061,1)
+        // e.g. can't index because of already existing duplicates
+    }
 };


### PR DESCRIPTION
## Summary
- modernizes lower-risk CLI entrypoints and helper modules from older `var`/promise-chain style to scoped bindings and `async`/`await`
- preserves high-risk migration executor chains while keeping connection teardown, locking, rollback, and CLI error behavior intact
- keeps the change scoped to production JavaScript files only

## Validation
- `pnpm lint && pnpm test`
- `pnpm coverage`
- `NODE_ENV=testing pnpm test`
- `NODE_ENV=testing-better-sqlite3 pnpm test`
- focused unit/functional migration and rollback suites
- `GHOST_CORE_PATH=/Users/aileen/code/tryghost/Ghost pnpm smoke:ghost`

## Notes
- `NODE_ENV=testing-mysql pnpm test` was not run locally because the repo test config expects root with an empty password and local MySQL rejected that access.