### PR TITLE
✨ Added support for .cjs/.mjs MigratorConfig files

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -82,11 +82,10 @@ jobs:
         with:
           repository: TryGhost/Ghost
           path: Ghost
-          fetch-depth: 0
           persist-credentials: false
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
-          node-version: '22.18.0'
+          node-version: '22.23.1'
       - name: Install Corepack
         run: npm install --global corepack@0.34.6
       - name: Enable corepack
@@ -97,6 +96,9 @@ jobs:
       - name: Install Ghost dependencies
         working-directory: Ghost
         run: pnpm install --frozen-lockfile --filter ghost...
+      - name: Build Ghost Workspace dependencies
+        run: pnpm --filter ghost^... build
+        working-directory: Ghost
       - name: Use linked knex-migrator in Ghost
         working-directory: Ghost/ghost/core
         run: pnpm link ${{ github.workspace }}/knex-migrator

--- a/README.md
+++ b/README.md
@@ -42,6 +42,17 @@ The `mysql` client name is accepted for backwards compatibility and is mapped to
 
 Add `MigratorConfig.js` to the project root that will run migrations. CLI commands load this file from the current working directory by default, or from the directory passed with `--mgpath`.
 
+`MigratorConfig.cjs` and `MigratorConfig.mjs` are also supported and are resolved in that order after `MigratorConfig.js`. ESM configs (`.mjs`, or `.js`/`.cjs` in a `"type": "module"` package) are loaded synchronously, so they must export the config as the `default` export and must not use top-level `await`:
+
+```js
+// MigratorConfig.mjs
+export default {
+    database: { /* ... */ },
+    migrationPath: '/path/to/project/migrations',
+    currentVersion: '2.0'
+};
+```
+
 ```js
 module.exports = {
     database: {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -6,10 +6,38 @@ const debug = require('debug')('knex-migrator:utils');
 const errors = require('./errors');
 
 /**
+ * @description The config file basenames we look for, in resolution order.
+ *
+ * `.mjs` and `.cjs` are supported alongside the historical `.js`. ESM configs
+ * are loaded synchronously via `require()` (Node >= 22.13 / >= 24), so they must
+ * not use top-level await.
+ */
+const CONFIG_FILENAMES = ['MigratorConfig.js', 'MigratorConfig.cjs', 'MigratorConfig.mjs'];
+
+/**
+ * @description Unwrap the config from a loaded module.
+ *
+ * `require()`-ing an ESM module (a `.mjs` file, or a `.js`/`.cjs` file in a
+ * `"type": "module"` package) returns a Module namespace object whose config
+ * lives on the `default` export. CommonJS modules return `module.exports`
+ * directly.
+ *
+ * @param {*} loaded
+ * @returns {*}
+ */
+function interopConfig(loaded) {
+    if (loaded && loaded[Symbol.toStringTag] === 'Module' && 'default' in loaded) {
+        return loaded.default;
+    }
+
+    return loaded;
+}
+
+/**
  * @description This helper function offers two ways of loading the knex-migrator configuration.
  *
  * 1. via JS object
- * 2. via file location
+ * 2. via file location (`MigratorConfig.js`, `MigratorConfig.cjs`, or `MigratorConfig.mjs`)
  *
  * The expected format is:
  *
@@ -27,25 +55,33 @@ module.exports.loadConfig = function loadConfig(options) {
         return options.knexMigratorConfig;
     }
 
-    const knexMigratorFilePath = options.knexMigratorFilePath || process.cwd();
-    const configPath = path.join(path.resolve(knexMigratorFilePath), 'MigratorConfig.js');
+    const knexMigratorFilePath = path.resolve(options.knexMigratorFilePath || process.cwd());
     let resolvedConfigPath;
 
-    try {
-        resolvedConfigPath = require.resolve(configPath);
-    } catch (err) {
-        if (err.code === 'MODULE_NOT_FOUND') {
-            throw new errors.KnexMigrateError({
-                message: 'Please provide a file named MigratorConfig.js in your project root.',
-                help: 'Read through the README.md to see which values are expected.',
-            });
-        }
+    for (const filename of CONFIG_FILENAMES) {
+        try {
+            resolvedConfigPath = require.resolve(path.join(knexMigratorFilePath, filename));
+            break;
+        } catch (err) {
+            // CASE: this candidate does not exist, try the next one.
+            if (err.code === 'MODULE_NOT_FOUND') {
+                continue;
+            }
 
-        throw new errors.KnexMigrateError({ err: err });
+            throw new errors.KnexMigrateError({ err: err });
+        }
+    }
+
+    if (!resolvedConfigPath) {
+        throw new errors.KnexMigrateError({
+            message:
+                'Please provide a file named MigratorConfig.js, MigratorConfig.cjs, or MigratorConfig.mjs in your project root.',
+            help: 'Read through the README.md to see which values are expected.',
+        });
     }
 
     try {
-        return require(resolvedConfigPath);
+        return interopConfig(require(resolvedConfigPath));
     } catch (err) {
         throw new errors.KnexMigrateError({ err: err });
     }

--- a/test/unit/fixtures/cjs-config/MigratorConfig.cjs
+++ b/test/unit/fixtures/cjs-config/MigratorConfig.cjs
@@ -1,0 +1,5 @@
+module.exports = {
+    database: { client: 'sqlite3' },
+    migrationPath: 'migrations',
+    currentVersion: '1.0',
+};

--- a/test/unit/fixtures/mjs-config/MigratorConfig.mjs
+++ b/test/unit/fixtures/mjs-config/MigratorConfig.mjs
@@ -1,0 +1,5 @@
+export default {
+    database: { client: 'sqlite3' },
+    migrationPath: 'migrations',
+    currentVersion: '1.0',
+};

--- a/test/unit/utils_spec.js
+++ b/test/unit/utils_spec.js
@@ -24,7 +24,7 @@ describe('Utils', function () {
                 .should.eql(config);
         });
 
-        it('throws a helpful error when MigratorConfig.js is missing', function () {
+        it('throws a helpful error when no config file is present', function () {
             try {
                 utils.loadConfig({
                     knexMigratorFilePath: path.join(__dirname, 'missing-config'),
@@ -33,9 +33,37 @@ describe('Utils', function () {
             } catch (err) {
                 should.not.exist(err.code);
                 err.message.should.eql(
-                    'Please provide a file named MigratorConfig.js in your project root.',
+                    'Please provide a file named MigratorConfig.js, MigratorConfig.cjs, or MigratorConfig.mjs in your project root.',
                 );
             }
+        });
+
+        it('loads a CommonJS config from MigratorConfig.cjs', function () {
+            const configPath = path.join(__dirname, 'fixtures', 'cjs-config');
+
+            utils
+                .loadConfig({
+                    knexMigratorFilePath: configPath,
+                })
+                .should.eql({
+                    database: { client: 'sqlite3' },
+                    migrationPath: 'migrations',
+                    currentVersion: '1.0',
+                });
+        });
+
+        it('loads an ESM config from MigratorConfig.mjs via its default export', function () {
+            const configPath = path.join(__dirname, 'fixtures', 'mjs-config');
+
+            utils
+                .loadConfig({
+                    knexMigratorFilePath: configPath,
+                })
+                .should.eql({
+                    database: { client: 'sqlite3' },
+                    migrationPath: 'migrations',
+                    currentVersion: '1.0',
+                });
         });
 
         it('does not hide missing dependencies from MigratorConfig.js', function () {


### PR DESCRIPTION
no ref
- add support for synchronous require of .cjs or .mjs MigratorConfig files, allowing esm usage