### PR TITLE
✨ Added support for mysql GET_LOCK for locking

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,35 @@ module.exports = {
 
 `subfolder` is optional and defaults to `versions`.
 
+### Lock wait (MySQL)
+
+`lock` is optional and groups lock-related settings. `lock.waitSeconds`
+controls how long knex-migrator waits for an in-progress migration to finish
+before giving up when acquiring the migration lock. It only applies to
+MySQL/MariaDB, where it maps to the timeout of a session-scoped
+[`GET_LOCK`](https://dev.mysql.com/doc/refman/en/locking-functions.html)
+advisory lock; on SQLite it is ignored. It defaults to `30` seconds.
+
+```js
+module.exports = {
+    database: { /* ... */ },
+    migrationPath: '/path/to/project/migrations',
+    currentVersion: '2.0',
+    lock: {
+        waitSeconds: 30
+    }
+};
+```
+
+The advisory lock is released automatically if the migrating process dies, so a
+container killed mid-migration no longer leaves the database locked. When
+several processes start at once, the losers wait up to `lock.waitSeconds` for
+the leader to finish rather than failing immediately.
+
+Set the `KNEX_MIGRATOR_LOCK_WAIT_SECONDS` environment variable to override
+`lock.waitSeconds` at runtime (useful for tuning a single deployment without
+changing `MigratorConfig`).
+
 ## Migration Structure
 
 The default migration layout separates one-time init scripts from versioned migrations.

--- a/lib/database.js
+++ b/lib/database.js
@@ -120,6 +120,85 @@ module.exports.createTransaction = function (connection, callback) {
 };
 
 /**
+ * @description Whether the given knex connection talks to MySQL/MariaDB.
+ *
+ * Guarded so it can be called with the bare stub objects used in unit tests
+ * (and any not-yet-connected knex instance) without throwing.
+ *
+ * @param {import('knex').Knex} connection
+ * @returns {boolean}
+ */
+exports.isMySQL = function isMySQL(connection) {
+    try {
+        return DatabaseInfo.isMySQL(connection);
+    } catch (err) {
+        debug('Could not detect database client: ' + err.message);
+        return false;
+    }
+};
+
+/**
+ * @description Acquire a dedicated connection from the pool, bypassing the
+ * regular query path.
+ *
+ * Used to hold a session-scoped MySQL advisory lock (`GET_LOCK`) for the
+ * lifetime of a migration: the lock only stays held while *this* connection is
+ * open, so it is released automatically if the process dies. The caller MUST
+ * hand the connection back via {@link releaseRawConnection}.
+ *
+ * @WARNING: `client.acquireConnection()` is NOT part of knex's public API. It is
+ * stable in practice, but any knex major *or minor* bump must audit this call
+ * (and {@link releaseRawConnection}) for behavioural changes. If it ever breaks,
+ * the alternative is a second knex instance configured with `pool: {min: 1,
+ * max: 1}` dedicated to holding the lock.
+ *
+ * @param {import('knex').Knex} connection
+ * @returns {Promise<any>} the raw driver connection
+ */
+exports.acquireRawConnection = function acquireRawConnection(connection) {
+    return connection.client.acquireConnection();
+};
+
+/**
+ * @description Return a raw connection acquired via {@link acquireRawConnection}
+ * back to the pool.
+ *
+ * @WARNING: `client.releaseConnection()` is NOT part of knex's public API — see
+ * the note on {@link acquireRawConnection}.
+ *
+ * @param {import('knex').Knex} connection
+ * @param {any} rawConnection
+ * @returns {Promise<void>}
+ */
+exports.releaseRawConnection = function releaseRawConnection(connection, rawConnection) {
+    return connection.client.releaseConnection(rawConnection);
+};
+
+/**
+ * @description Run a query on a raw (pool-bypassing) driver connection.
+ *
+ * Kept deliberately small so that advisory-lock SQL (`GET_LOCK`/`RELEASE_LOCK`)
+ * runs on the exact same session that must own the lock.
+ *
+ * @param {any} rawConnection - a mysql2 driver connection
+ * @param {string} sql
+ * @param {Array} [bindings]
+ * @returns {Promise<any>}
+ */
+exports.rawQuery = function rawQuery(rawConnection, sql, bindings) {
+    return new Promise(function (resolve, reject) {
+        rawConnection.query(sql, bindings || [], function (err, rows) {
+            if (err) {
+                reject(err);
+                return;
+            }
+
+            resolve(rows);
+        });
+    });
+};
+
+/**
  * @description Helper to create the migration table.
  *
  * @TODO: https://github.com/TryGhost/knex-migrator/issues/118

--- a/lib/index.js
+++ b/lib/index.js
@@ -34,6 +34,13 @@ function KnexMigrator(options = {}) {
     this.migrationPath = config.migrationPath;
     this.subfolder = config.subfolder || 'versions';
 
+    // Optional lock tuning. `lock.waitSeconds` controls how long (seconds) to
+    // wait for an in-progress migration before giving up when acquiring the
+    // lock. Only honoured on MySQL, where it maps to the `GET_LOCK` timeout.
+    // Overridable at runtime via `KNEX_MIGRATOR_LOCK_WAIT_SECONDS`. See
+    // lib/locking.js for precedence.
+    this.lockWaitSeconds = config.lock && config.lock.waitSeconds;
+
     this.dbConfig = config.database;
     this.knexModulePath = options.knexMigratorFilePath || process.cwd();
 }
@@ -95,7 +102,7 @@ KnexMigrator.prototype.init = function init(options) {
             return database.createMigrationsTable(self.connection).then(function () {
                 return migrations.run(self.connection).then(function () {
                     return locking
-                        .lock(self.connection)
+                        .lock(self.connection, { waitSeconds: self.lockWaitSeconds })
                         .then(function () {
                             if (hooks.before) {
                                 debug('Before hook');
@@ -266,6 +273,15 @@ KnexMigrator.prototype.init = function init(options) {
         .finally(function () {
             let ops = [];
 
+            // Safety net: free the advisory lock before the connection closes, in
+            // case an error path skipped unlock().
+            ops.push(function releaseLock() {
+                return locking.releaseAdvisoryLock(self.connection).catch(function (err) {
+                    // Never abort the sequence: destroyConnection must still run.
+                    debug('Advisory lock release failed: ' + err.message);
+                });
+            });
+
             if (hooks.shutdown) {
                 ops.push(function shutdownHook() {
                     debug('Shutdown hook');
@@ -347,7 +363,7 @@ KnexMigrator.prototype.migrate = async function migrate(options) {
 
         await migrations.run(this.connection);
 
-        await locking.lock(this.connection);
+        await locking.lock(this.connection, { waitSeconds: this.lockWaitSeconds });
 
         const result = await this._integrityCheck({ force });
 
@@ -455,6 +471,14 @@ KnexMigrator.prototype.migrate = async function migrate(options) {
         }
         await locking.unlock(this.connection);
     } finally {
+        // Safety net: free the advisory lock before the connection closes, in
+        // case an error path skipped unlock() (e.g. the integrity check threw).
+        try {
+            await locking.releaseAdvisoryLock(this.connection);
+        } catch (err) {
+            debug('Advisory lock release failed: ' + err.message);
+        }
+
         if (hooks.shutdown) {
             debug('Shutdown hook');
             await hooks.shutdown({
@@ -519,7 +543,7 @@ KnexMigrator.prototype.reset = async function reset(options) {
     try {
         await database.ensureConnectionWorks(this.connection);
         await migrations.run(this.connection);
-        await locking.lock(this.connection);
+        await locking.lock(this.connection, { waitSeconds: this.lockWaitSeconds });
         await database.drop({
             connection: this.connection,
             dbConfig: this.dbConfig,
@@ -544,6 +568,15 @@ KnexMigrator.prototype.reset = async function reset(options) {
         await locking.unlock(this.connection);
         throw err;
     } finally {
+        // Safety net: a successful reset drops the database (and the
+        // migrations_lock table) without calling unlock(), so free the advisory
+        // lock here before the connection closes.
+        try {
+            await locking.releaseAdvisoryLock(this.connection);
+        } catch (err) {
+            debug('Advisory lock release failed: ' + err.message);
+        }
+
         debug('Destroy connection');
         await this.connection.destroy();
         debug('Destroyed connection');

--- a/lib/locking.js
+++ b/lib/locking.js
@@ -1,21 +1,199 @@
 const moment = require('moment');
 const debug = require('debug')('knex-migrator:locking');
+const logging = require('@tryghost/logging');
 const errors = require('./errors');
 const database = require('./database');
 
+const LOCK_KEY = 'km01';
+
+// Default time the losing contender waits for an in-progress migration to
+// finish before giving up. Overridable per-call or via env var so a
+// multi-container deployment can tune it without a code change.
+const DEFAULT_LOCK_WAIT_SECONDS = 30;
+
+// Stashed on the knex instance by the MySQL advisory path so that unlock() can
+// find the parked connection that owns the advisory lock.
+const ADVISORY_STATE = Symbol.for('knex-migrator:advisory-lock');
+
 /**
- * @description Private helper to lock the migrations_lock table.
- * @TODO Locks in Sqlite won't work, because Sqlite doesn't offer read locks (https://github.com/TryGhost/knex-migrator/issues/87)
- * @returns {*}
+ * @description Resolve how long to wait for an in-progress migration.
+ *
+ * Precedence: `KNEX_MIGRATOR_LOCK_WAIT_SECONDS` env var → configured
+ * `waitSeconds` (from `MigratorConfig.lockWaitSeconds`) → default. The env var
+ * wins so a deployment can tune the wait per-container without rebuilding config.
+ * Non-numeric / negative values are ignored and fall through to the next source.
+ * @returns {number}
  */
-module.exports.lock = function lock(connection) {
+function resolveWaitSeconds(options) {
+    const candidates = [
+        process.env.KNEX_MIGRATOR_LOCK_WAIT_SECONDS,
+        options && options.waitSeconds,
+    ];
+
+    for (const candidate of candidates) {
+        if (candidate === undefined || candidate === null || candidate === '') {
+            continue;
+        }
+
+        const parsed = Number.parseInt(candidate, 10);
+        if (Number.isFinite(parsed) && parsed >= 0) {
+            return parsed;
+        }
+    }
+
+    return DEFAULT_LOCK_WAIT_SECONDS;
+}
+
+/**
+ * @description Build the `GET_LOCK` name.
+ *
+ * MySQL advisory-lock names are scoped to the whole server (shared across every
+ * database on the host) and capped at 64 characters, so we namespace by the
+ * database name to avoid two Ghost sites on one MySQL server serialising
+ * against each other.
+ * @returns {string}
+ */
+function advisoryLockName(connection) {
+    let name = '';
+
+    try {
+        name = connection.client.config.connection.database || '';
+    } catch {
+        name = '';
+    }
+
+    return ('km_migration_' + (name || 'default')).slice(0, 64);
+}
+
+/**
+ * @description Acquire the migration lock.
+ *
+ * On MySQL this holds a session-scoped advisory lock (`GET_LOCK`) that is
+ * released automatically if the process dies, and waits (rather than throwing
+ * immediately) for an in-progress migration to finish. On every other client
+ * it keeps the historic row-based behaviour.
+ *
+ * @param {import('knex').Knex} connection
+ * @param {Object} [options] - { waitSeconds }
+ * @returns {Promise<*>}
+ */
+module.exports.lock = function lock(connection, options) {
     debug('Lock.');
 
+    if (database.isMySQL(connection)) {
+        return lockAdvisory(connection, options);
+    }
+
+    return lockRow(connection);
+};
+
+/**
+ * @description MySQL advisory lock acquisition.
+ *
+ * 1. Park a dedicated connection and take a session-scoped `GET_LOCK`, blocking
+ *    up to `waitSeconds` — this is the bounded wait-then-recheck.
+ * 2. Holding the advisory lock proves no other process is *actively* migrating.
+ *    Claim the persistent `migrations_lock` row. If it is still flagged locked,
+ *    a previous holder died without releasing it (its advisory lock auto-released
+ *    on disconnect): reclaim the row instead of bricking the database.
+ * 3. Keep the parked connection open for the migration's lifetime.
+ */
+async function lockAdvisory(connection, options) {
+    const waitSeconds = resolveWaitSeconds(options);
+    const name = advisoryLockName(connection);
+
+    let raw;
+    let acquired = false;
+
+    try {
+        // Park a dedicated connection; the advisory lock lives on this session.
+        raw = await database.acquireRawConnection(connection);
+
+        // GET_LOCK(name, timeout): 1 = acquired, 0 = timed out, NULL = error.
+        const rows = await database.rawQuery(raw, 'SELECT GET_LOCK(?, ?) AS acquired', [
+            name,
+            waitSeconds,
+        ]);
+        const raw0 = rows && rows[0] ? rows[0].acquired : null;
+        // CASE: NULL means the server errored (e.g. out of memory, killed
+        // thread) — that is not lock contention, so surface it as a LockError.
+        if (raw0 === null || raw0 === undefined) {
+            throw new errors.LockError({
+                message: 'Error while acquire the migration lock.',
+                context: `GET_LOCK('${name}') returned NULL, which indicates a database error rather than a competing migration.`,
+            });
+        }
+
+        if (Number(raw0) !== 1) {
+            throw new errors.MigrationsAreLockedError({
+                message:
+                    'Migrations are running at the moment. Please wait that the lock get`s released.',
+                context: `Could not acquire the migration lock within ${waitSeconds}s — a parallel process is migrating.`,
+                help: `If your database looks okay, inspect the lock with \`SELECT IS_USED_LOCK('${name}');\`.`,
+            });
+        }
+
+        acquired = true;
+
+        const lockRows = await connection('migrations_lock').where({
+            lock_key: LOCK_KEY,
+        });
+        const row = lockRows && lockRows[0];
+
+        // CASE: no lock row to claim. Matches lockRow()/isLocked() — never report
+        // success without a persisted lock record to later release.
+        if (!row) {
+            throw new errors.MigrationsAreLockedError({
+                message:
+                    'Migrations are running at the moment. Please wait that the lock get`s released.',
+                context: 'The migrations_lock row is missing.',
+                help: "If your database looks okay, you can restore the lock row by running `INSERT INTO migrations_lock (lock_key, locked) VALUES ('km01', 0);`.",
+            });
+        }
+
+        if (row.locked) {
+            logging.warn(
+                'knex-migrator reclaimed a stale migration lock — a previous migration process ' +
+                    'exited without releasing it. Continuing.',
+            );
+        }
+
+        await connection('migrations_lock')
+            .where({
+                lock_key: LOCK_KEY,
+            })
+            .update({
+                locked: 1,
+                acquired_at: moment().format('YYYY-MM-DD HH:mm:ss'),
+            });
+
+        // Park the connection + name so unlock() can release the advisory lock.
+        connection[ADVISORY_STATE] = { raw, name };
+    } catch (err) {
+        await releaseAdvisory(connection, { raw, name }, acquired);
+
+        if (errors.utils.isGhostError(err)) {
+            throw err;
+        }
+
+        throw new errors.LockError({
+            message: 'Error while acquire the migration lock.',
+            err: err,
+        });
+    }
+}
+
+/**
+ * @description Row-based lock acquisition (SQLite and any non-MySQL client).
+ * Historic behaviour: throw immediately if the lock is already held.
+ * @TODO: Locks in Sqlite won't work, because Sqlite doesn't offer read locks (https://github.com/TryGhost/knex-migrator/issues/87)
+ */
+function lockRow(connection) {
     return database.createTransaction(connection, async function (transacting) {
         try {
             const data = await transacting('migrations_lock')
                 .where({
-                    lock_key: 'km01',
+                    lock_key: LOCK_KEY,
                 })
                 .forUpdate();
 
@@ -31,7 +209,7 @@ module.exports.lock = function lock(connection) {
 
             return (transacting || connection)('migrations_lock')
                 .where({
-                    lock_key: 'km01',
+                    lock_key: LOCK_KEY,
                 })
                 .update({
                     locked: 1,
@@ -48,15 +226,20 @@ module.exports.lock = function lock(connection) {
             });
         }
     });
-};
+}
 
 /**
  * @description Private helper to determine whether the database is locked or not.
+ *
+ * Intentionally reads the persistent `migrations_lock` row on every client: a
+ * crashed migration leaves the row flagged (even though the MySQL advisory lock
+ * auto-releases), which is what lets `rollback` detect a broken state and
+ * recover.
  * @returns {boolean}
  */
 module.exports.isLocked = async function isLocked(connection) {
     const data = await connection('migrations_lock').where({
-        lock_key: 'km01',
+        lock_key: LOCK_KEY,
     });
 
     if (!data || !data.length || data[0].locked) {
@@ -70,18 +253,132 @@ module.exports.isLocked = async function isLocked(connection) {
 };
 
 /**
- * @description Private helper to unlock the database table "migrations_lock".
- * @TODO Locks in Sqlite won't work, because Sqlite doesn't offer read locks (https://github.com/TryGhost/knex-migrator/issues/87)
- * @returns {*}
+ * @description Release the migration lock.
+ *
+ * Mirrors {@link module:locking.lock}: if the MySQL advisory path acquired the
+ * lock, release both the persistent row and the parked advisory lock; otherwise
+ * fall back to the historic row-based unlock.
+ *
+ * @param {import('knex').Knex} connection
+ * @returns {Promise<*>}
  */
 module.exports.unlock = function unlock(connection) {
     debug('Unlock.');
 
+    const state = connection[ADVISORY_STATE];
+    if (state) {
+        return unlockAdvisory(connection, state);
+    }
+
+    return unlockRow(connection);
+};
+
+/**
+ * @description Best-effort safety net that releases a still-held MySQL advisory
+ * lock and hands its parked connection back.
+ *
+ * `unlock()` is the normal release path, but some commands acquire the lock and
+ * legitimately never call it — e.g. `reset()` drops the whole database (and with
+ * it the `migrations_lock` table) on success. Without this, the parked
+ * connection returns to the pool still holding `GET_LOCK`, and every subsequent
+ * migrator blocks until the wait timeout. Call this from each command's
+ * `finally`, before destroying the connection: it is idempotent and a no-op once
+ * `unlock()` has already run (or on the row-based/SQLite path), so it is always
+ * safe to call. It never throws.
+ *
+ * @param {import('knex').Knex} connection
+ * @returns {Promise<void>}
+ */
+module.exports.releaseAdvisoryLock = async function releaseAdvisoryLock(connection) {
+    const state = connection && connection[ADVISORY_STATE];
+    if (!state) {
+        return;
+    }
+
+    // State is only ever set once GET_LOCK has succeeded, so treat it as acquired.
+    await releaseAdvisory(connection, state, true);
+};
+
+/**
+ * @description Release the persistent row and the parked advisory lock.
+ */
+async function unlockAdvisory(connection, state) {
+    delete connection[ADVISORY_STATE];
+
+    try {
+        await connection('migrations_lock')
+            .where({
+                lock_key: LOCK_KEY,
+            })
+            .update({
+                locked: 0,
+                released_at: moment().format('YYYY-MM-DD HH:mm:ss'),
+            });
+    } catch (err) {
+        if (errors.utils.isGhostError(err)) {
+            throw err;
+        }
+
+        throw new errors.UnlockError({
+            message: 'Error while releasing the migration lock.',
+            err: err,
+        });
+    } finally {
+        // Always release the advisory lock and hand the connection back — even if
+        // the row update above threw. Otherwise a still-locked connection returns
+        // to the pool and the next GET_LOCK on it blocks until timeout. Cleanup
+        // failures are swallowed so they cannot mask the original error.
+        try {
+            await database.rawQuery(state.raw, 'SELECT RELEASE_LOCK(?)', [state.name]);
+        } catch {
+            // Best effort: the lock also auto-releases when the connection closes.
+        }
+
+        try {
+            await database.releaseRawConnection(connection, state.raw);
+        } catch {
+            // Best effort.
+        }
+    }
+}
+
+/**
+ * @description Best-effort teardown of a partially/​fully acquired advisory lock
+ * when acquisition fails.
+ */
+async function releaseAdvisory(connection, state, acquired) {
+    delete connection[ADVISORY_STATE];
+
+    // Acquiring the pooled connection itself failed — nothing to release.
+    if (!state.raw) {
+        return;
+    }
+
+    if (acquired) {
+        try {
+            await database.rawQuery(state.raw, 'SELECT RELEASE_LOCK(?)', [state.name]);
+        } catch {
+            // Best effort: the lock also auto-releases when we drop the connection.
+        }
+    }
+
+    try {
+        await database.releaseRawConnection(connection, state.raw);
+    } catch {
+        // Best effort.
+    }
+}
+
+/**
+ * @description Row-based unlock (SQLite and any non-MySQL client).
+ * @TODO: Locks in Sqlite won't work, because Sqlite doesn't offer read locks (https://github.com/TryGhost/knex-migrator/issues/87)
+ */
+function unlockRow(connection) {
     return database.createTransaction(connection, async function (transacting) {
         try {
             const data = await transacting('migrations_lock')
                 .where({
-                    lock_key: 'km01',
+                    lock_key: LOCK_KEY,
                 })
                 .forUpdate();
 
@@ -93,7 +390,7 @@ module.exports.unlock = function unlock(connection) {
 
             return transacting('migrations_lock')
                 .where({
-                    lock_key: 'km01',
+                    lock_key: LOCK_KEY,
                 })
                 .update({
                     locked: 0,
@@ -110,4 +407,4 @@ module.exports.unlock = function unlock(connection) {
             });
         }
     });
-};
+}

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -44,7 +44,9 @@ function interopConfig(loaded) {
  * {
  *   database: Object,
  *   migrationPath: String,
- *   currentVersion: String
+ *   currentVersion: String,
+ *   subfolder: String,                 // optional, defaults to 'versions'
+ *   lock: { waitSeconds: Number }      // optional, MySQL only; GET_LOCK timeout
  * }
  *
  * @param {Object} options

--- a/test/unit/database_spec.js
+++ b/test/unit/database_spec.js
@@ -449,4 +449,64 @@ describe('Database', function () {
                 });
         });
     });
+
+    describe('isMySQL', function () {
+        it('detects a mysql connection', function () {
+            const connection = database.connect({
+                client: 'mysql',
+                connection: { filename: 'unused.db' },
+            });
+
+            database.isMySQL(connection).should.eql(true);
+
+            return connection.destroy();
+        });
+
+        it('returns false for sqlite connections', function () {
+            const connection = database.connect({
+                client: 'sqlite3',
+                connection: { filename: ':memory:' },
+            });
+
+            database.isMySQL(connection).should.eql(false);
+
+            return connection.destroy();
+        });
+
+        it('returns false (does not throw) for bare stub objects', function () {
+            database.isMySQL({}).should.eql(false);
+        });
+    });
+
+    describe('rawQuery', function () {
+        it('resolves the driver rows', function () {
+            const rawConnection = {
+                query: function (sql, bindings, cb) {
+                    cb(null, [{ ok: 1 }]);
+                },
+            };
+
+            return database.rawQuery(rawConnection, 'SELECT 1', []).then(function (rows) {
+                rows.should.eql([{ ok: 1 }]);
+            });
+        });
+
+        it('rejects on a driver error', function () {
+            const boom = new Error('driver failed');
+            const rawConnection = {
+                query: function (sql, bindings, cb) {
+                    cb(boom);
+                },
+            };
+
+            return database
+                .rawQuery(rawConnection, 'SELECT 1')
+                .then(function () {
+                    true.should.eql(false);
+                })
+                .catch(function (err) {
+                    err.should.equal(boom);
+                });
+        });
+    });
 });

--- a/test/unit/index_spec.js
+++ b/test/unit/index_spec.js
@@ -490,6 +490,33 @@ describe('KnexMigrator', function () {
                 });
         });
 
+        it('threads the configured lock.waitSeconds through to locking.lock', function () {
+            const knexMigrator = new KnexMigrator({
+                knexMigratorConfig: {
+                    database: {},
+                    migrationPath: path.join(__dirname, '..', 'assets', 'migrations'),
+                    currentVersion: '1.0',
+                    lock: {
+                        waitSeconds: 45,
+                    },
+                },
+            });
+            const connection = createDestroyableConnection();
+
+            knexMigrator.lockWaitSeconds.should.eql(45);
+
+            sinon.stub(database, 'connect').returns(connection);
+            sinon.stub(database, 'ensureConnectionWorks').resolves();
+            sinon.stub(migrations, 'run').resolves();
+            sinon.stub(locking, 'lock').resolves();
+            sinon.stub(locking, 'unlock').resolves();
+            sinon.stub(knexMigrator, '_integrityCheck').resolves({});
+
+            return knexMigrator.migrate().then(function () {
+                locking.lock.calledOnceWith(connection, { waitSeconds: 45 }).should.eql(true);
+            });
+        });
+
         it('warns when the requested version is not present', function () {
             const knexMigrator = createKnexMigrator();
             const connection = createDestroyableConnection();

--- a/test/unit/locking_spec.js
+++ b/test/unit/locking_spec.js
@@ -1,8 +1,12 @@
 const sinon = require('sinon');
+const logging = require('@tryghost/logging');
 
 const database = require('../../lib/database');
 const errors = require('../../lib/errors');
 const locking = require('../../lib/locking');
+
+// Mirrors the symbol lib/locking.js parks the advisory-lock state under.
+const ADVISORY_STATE = Symbol.for('knex-migrator:advisory-lock');
 
 function createLockTable(data) {
     return function lockTable() {
@@ -28,13 +32,43 @@ function createRejectedLockTable(err) {
     };
 }
 
+/**
+ * Builds a knex-instance stub for the MySQL advisory path. `connection('migrations_lock')`
+ * returns a builder whose `.where()` result is both awaitable (resolves the SELECT
+ * rows) and exposes `.update()`.
+ */
+function createAdvisoryConnection(options) {
+    options = options || {};
+    const selectRows = options.selectRows || [{ locked: 0 }];
+    const update = sinon.stub();
+    if (options.updateRejects) {
+        update.rejects(options.updateRejects);
+    } else {
+        update.resolves(1);
+    }
+
+    const where = sinon.stub().returns({
+        update,
+        then: function (resolve, reject) {
+            return Promise.resolve(selectRows).then(resolve, reject);
+        },
+    });
+
+    const connection = sinon.stub().returns({ where });
+    connection.client = { config: { connection: { database: 'ghost_test' } } };
+
+    return { connection, where, update };
+}
+
 describe('Locking', function () {
     afterEach(function () {
         sinon.restore();
+        delete process.env.KNEX_MIGRATOR_LOCK_WAIT_SECONDS;
     });
 
-    describe('lock', function () {
+    describe('lock (row-based / non-MySQL)', function () {
         it('rejects when the migration lock row is missing', function () {
+            sinon.stub(database, 'isMySQL').returns(false);
             sinon.stub(database, 'createTransaction').callsFake(function (connection, callback) {
                 return callback(createLockTable([]));
             });
@@ -50,6 +84,7 @@ describe('Locking', function () {
         });
 
         it('wraps unexpected lock acquisition errors', function () {
+            sinon.stub(database, 'isMySQL').returns(false);
             sinon.stub(database, 'createTransaction').callsFake(function (connection, callback) {
                 return callback(createRejectedLockTable(new Error('driver failed')));
             });
@@ -63,6 +98,209 @@ describe('Locking', function () {
                     err.should.be.instanceof(errors.LockError);
                     err.message.should.eql('Error while acquire the migration lock.');
                 });
+        });
+    });
+
+    describe('lock (MySQL advisory)', function () {
+        it('takes GET_LOCK, flags the row, and parks the connection', async function () {
+            const raw = { id: 'raw-conn' };
+            sinon.stub(database, 'isMySQL').returns(true);
+            sinon.stub(database, 'acquireRawConnection').resolves(raw);
+            const releaseRaw = sinon.stub(database, 'releaseRawConnection').resolves();
+            const rawQuery = sinon.stub(database, 'rawQuery').resolves([{ acquired: 1 }]);
+
+            const { connection, update } = createAdvisoryConnection();
+
+            await locking.lock(connection);
+
+            // GET_LOCK invoked with a db-namespaced name and the default 30s wait.
+            rawQuery.calledOnce.should.eql(true);
+            rawQuery.firstCall.args[1].should.eql('SELECT GET_LOCK(?, ?) AS acquired');
+            rawQuery.firstCall.args[2].should.eql(['km_migration_ghost_test', 30]);
+
+            // Persistent row flagged locked=1.
+            update.calledOnce.should.eql(true);
+            update.firstCall.args[0].locked.should.eql(1);
+
+            // Parked connection retained for unlock(); NOT released.
+            releaseRaw.called.should.eql(false);
+            connection[ADVISORY_STATE].raw.should.equal(raw);
+        });
+
+        it('waits then throws MigrationsAreLockedError when GET_LOCK times out', async function () {
+            const raw = { id: 'raw-conn' };
+            sinon.stub(database, 'isMySQL').returns(true);
+            sinon.stub(database, 'acquireRawConnection').resolves(raw);
+            const releaseRaw = sinon.stub(database, 'releaseRawConnection').resolves();
+            sinon.stub(database, 'rawQuery').resolves([{ acquired: 0 }]);
+
+            const { connection, update } = createAdvisoryConnection();
+
+            let caught;
+            try {
+                await locking.lock(connection);
+            } catch (err) {
+                caught = err;
+            }
+
+            caught.should.be.instanceof(errors.MigrationsAreLockedError);
+            // Never touched the row, and handed the parked connection back.
+            update.called.should.eql(false);
+            releaseRaw.calledOnceWith(connection, raw).should.eql(true);
+            (connection[ADVISORY_STATE] === undefined).should.eql(true);
+        });
+
+        it('wraps a pooled-connection acquisition failure as LockError', async function () {
+            sinon.stub(database, 'isMySQL').returns(true);
+            sinon.stub(database, 'acquireRawConnection').rejects(new Error('pool exhausted'));
+            const releaseRaw = sinon.stub(database, 'releaseRawConnection').resolves();
+            const rawQuery = sinon.stub(database, 'rawQuery').resolves();
+
+            const { connection } = createAdvisoryConnection();
+
+            let caught;
+            try {
+                await locking.lock(connection);
+            } catch (err) {
+                caught = err;
+            }
+
+            caught.should.be.instanceof(errors.LockError);
+            // Nothing was acquired, so there is nothing to release.
+            rawQuery.called.should.eql(false);
+            releaseRaw.called.should.eql(false);
+            (connection[ADVISORY_STATE] === undefined).should.eql(true);
+        });
+
+        it('throws MigrationsAreLockedError when the lock row is missing', async function () {
+            const raw = { id: 'raw-conn' };
+            sinon.stub(database, 'isMySQL').returns(true);
+            sinon.stub(database, 'acquireRawConnection').resolves(raw);
+            const releaseRaw = sinon.stub(database, 'releaseRawConnection').resolves();
+            const rawQuery = sinon.stub(database, 'rawQuery').resolves([{ acquired: 1 }]);
+
+            // No migrations_lock row to claim.
+            const { connection, update } = createAdvisoryConnection({ selectRows: [] });
+
+            let caught;
+            try {
+                await locking.lock(connection);
+            } catch (err) {
+                caught = err;
+            }
+
+            caught.should.be.instanceof(errors.MigrationsAreLockedError);
+            // Never claims success without a persisted lock record.
+            update.called.should.eql(false);
+            (connection[ADVISORY_STATE] === undefined).should.eql(true);
+            // GET_LOCK succeeded, so it must be released again.
+            rawQuery.secondCall.args[1].should.eql('SELECT RELEASE_LOCK(?)');
+            releaseRaw.calledOnceWith(connection, raw).should.eql(true);
+        });
+
+        it('treats a NULL GET_LOCK result as a database error, not contention', async function () {
+            sinon.stub(database, 'isMySQL').returns(true);
+            sinon.stub(database, 'acquireRawConnection').resolves({});
+            const releaseRaw = sinon.stub(database, 'releaseRawConnection').resolves();
+            sinon.stub(database, 'rawQuery').resolves([{ acquired: null }]);
+
+            const { connection } = createAdvisoryConnection();
+
+            let caught;
+            try {
+                await locking.lock(connection);
+            } catch (err) {
+                caught = err;
+            }
+
+            caught.should.be.instanceof(errors.LockError);
+            caught.should.not.be.instanceof(errors.MigrationsAreLockedError);
+            releaseRaw.called.should.eql(true);
+        });
+
+        it('reclaims a stale row lock and warns', async function () {
+            const warn = sinon.stub(logging, 'warn');
+            sinon.stub(database, 'isMySQL').returns(true);
+            sinon.stub(database, 'acquireRawConnection').resolves({});
+            sinon.stub(database, 'releaseRawConnection').resolves();
+            sinon.stub(database, 'rawQuery').resolves([{ acquired: 1 }]);
+
+            // Row still flagged locked from a previous, crashed migration.
+            const { connection, update } = createAdvisoryConnection({
+                selectRows: [{ locked: 1 }],
+            });
+
+            await locking.lock(connection);
+
+            warn.calledOnce.should.eql(true);
+            warn.firstCall.args[0].should.match(/stale migration lock/);
+            update.firstCall.args[0].locked.should.eql(1);
+        });
+
+        it('uses the configured waitSeconds when no env var is set', async function () {
+            sinon.stub(database, 'isMySQL').returns(true);
+            sinon.stub(database, 'acquireRawConnection').resolves({});
+            sinon.stub(database, 'releaseRawConnection').resolves();
+            const rawQuery = sinon.stub(database, 'rawQuery').resolves([{ acquired: 1 }]);
+
+            const { connection } = createAdvisoryConnection();
+
+            await locking.lock(connection, { waitSeconds: 12 });
+
+            rawQuery.firstCall.args[2].should.eql(['km_migration_ghost_test', 12]);
+        });
+
+        it('lets KNEX_MIGRATOR_LOCK_WAIT_SECONDS override the configured value', async function () {
+            process.env.KNEX_MIGRATOR_LOCK_WAIT_SECONDS = '5';
+            sinon.stub(database, 'isMySQL').returns(true);
+            sinon.stub(database, 'acquireRawConnection').resolves({});
+            sinon.stub(database, 'releaseRawConnection').resolves();
+            const rawQuery = sinon.stub(database, 'rawQuery').resolves([{ acquired: 1 }]);
+
+            const { connection } = createAdvisoryConnection();
+
+            // env (5) beats the configured 12.
+            await locking.lock(connection, { waitSeconds: 12 });
+
+            rawQuery.firstCall.args[2].should.eql(['km_migration_ghost_test', 5]);
+        });
+
+        it('falls back to the 30s default when neither is set', async function () {
+            sinon.stub(database, 'isMySQL').returns(true);
+            sinon.stub(database, 'acquireRawConnection').resolves({});
+            sinon.stub(database, 'releaseRawConnection').resolves();
+            const rawQuery = sinon.stub(database, 'rawQuery').resolves([{ acquired: 1 }]);
+
+            const { connection } = createAdvisoryConnection();
+
+            await locking.lock(connection, { waitSeconds: undefined });
+
+            rawQuery.firstCall.args[2].should.eql(['km_migration_ghost_test', 30]);
+        });
+
+        it('releases the advisory lock and wraps row-update failures as LockError', async function () {
+            const raw = { id: 'raw-conn' };
+            sinon.stub(database, 'isMySQL').returns(true);
+            sinon.stub(database, 'acquireRawConnection').resolves(raw);
+            const releaseRaw = sinon.stub(database, 'releaseRawConnection').resolves();
+            const rawQuery = sinon.stub(database, 'rawQuery').resolves([{ acquired: 1 }]);
+
+            const { connection } = createAdvisoryConnection({
+                updateRejects: new Error('write failed'),
+            });
+
+            let caught;
+            try {
+                await locking.lock(connection);
+            } catch (err) {
+                caught = err;
+            }
+
+            caught.should.be.instanceof(errors.LockError);
+            // RELEASE_LOCK issued (GET_LOCK + RELEASE_LOCK == 2 calls) and connection returned.
+            rawQuery.callCount.should.eql(2);
+            rawQuery.secondCall.args[1].should.eql('SELECT RELEASE_LOCK(?)');
+            releaseRaw.calledOnceWith(connection, raw).should.eql(true);
         });
     });
 
@@ -93,7 +331,7 @@ describe('Locking', function () {
         });
     });
 
-    describe('unlock', function () {
+    describe('unlock (row-based / non-MySQL)', function () {
         it('rejects when the migration lock row is already released', function () {
             sinon.stub(database, 'createTransaction').callsFake(function (connection, callback) {
                 return callback(createLockTable([{ locked: 0 }]));
@@ -123,6 +361,108 @@ describe('Locking', function () {
                     err.should.be.instanceof(errors.UnlockError);
                     err.message.should.eql('Error while releasing the migration lock.');
                 });
+        });
+    });
+
+    describe('unlock (MySQL advisory)', function () {
+        it('clears the row, runs RELEASE_LOCK, and returns the parked connection', async function () {
+            const raw = { id: 'raw-conn' };
+            const releaseRaw = sinon.stub(database, 'releaseRawConnection').resolves();
+            const rawQuery = sinon.stub(database, 'rawQuery').resolves([{}]);
+
+            const { connection, update } = createAdvisoryConnection();
+            connection[ADVISORY_STATE] = {
+                raw,
+                name: 'km_migration_ghost_test',
+            };
+
+            await locking.unlock(connection);
+
+            // Row cleared to locked=0.
+            update.calledOnce.should.eql(true);
+            update.firstCall.args[0].locked.should.eql(0);
+
+            // RELEASE_LOCK on the parked session, then hand it back, then forget it.
+            rawQuery.calledOnceWith(raw, 'SELECT RELEASE_LOCK(?)').should.eql(true);
+            releaseRaw.calledOnceWith(connection, raw).should.eql(true);
+            (connection[ADVISORY_STATE] === undefined).should.eql(true);
+        });
+
+        it('releases the advisory lock and returns the connection even when the row update fails', async function () {
+            const raw = { id: 'raw-conn' };
+            const releaseRaw = sinon.stub(database, 'releaseRawConnection').resolves();
+            const rawQuery = sinon.stub(database, 'rawQuery').resolves();
+
+            const { connection } = createAdvisoryConnection({
+                updateRejects: new Error('write failed'),
+            });
+            connection[ADVISORY_STATE] = {
+                raw,
+                name: 'km_migration_ghost_test',
+            };
+
+            let caught;
+            try {
+                await locking.unlock(connection);
+            } catch (err) {
+                caught = err;
+            }
+
+            caught.should.be.instanceof(errors.UnlockError);
+            // Critically: RELEASE_LOCK still runs so a locked connection is never
+            // returned to the pool, then the connection is handed back.
+            rawQuery.calledOnceWith(raw, 'SELECT RELEASE_LOCK(?)').should.eql(true);
+            releaseRaw.calledOnceWith(connection, raw).should.eql(true);
+        });
+    });
+
+    describe('releaseAdvisoryLock', function () {
+        it('is a no-op when no advisory lock is parked', async function () {
+            const rawQuery = sinon.stub(database, 'rawQuery').resolves();
+            const releaseRaw = sinon.stub(database, 'releaseRawConnection').resolves();
+
+            await locking.releaseAdvisoryLock(sinon.stub());
+
+            rawQuery.called.should.eql(false);
+            releaseRaw.called.should.eql(false);
+        });
+
+        it('tolerates a null connection', async function () {
+            await locking.releaseAdvisoryLock(null);
+            await locking.releaseAdvisoryLock(undefined);
+        });
+
+        it('releases RELEASE_LOCK, returns the connection, and clears the state', async function () {
+            const raw = { id: 'raw-conn' };
+            const rawQuery = sinon.stub(database, 'rawQuery').resolves();
+            const releaseRaw = sinon.stub(database, 'releaseRawConnection').resolves();
+
+            const connection = sinon.stub();
+            connection[ADVISORY_STATE] = {
+                raw,
+                name: 'km_migration_ghost_test',
+            };
+
+            await locking.releaseAdvisoryLock(connection);
+
+            rawQuery.calledOnceWith(raw, 'SELECT RELEASE_LOCK(?)').should.eql(true);
+            releaseRaw.calledOnceWith(connection, raw).should.eql(true);
+            (connection[ADVISORY_STATE] === undefined).should.eql(true);
+        });
+
+        it('never throws, even when RELEASE_LOCK fails', async function () {
+            sinon.stub(database, 'rawQuery').rejects(new Error('gone'));
+            sinon.stub(database, 'releaseRawConnection').resolves();
+
+            const connection = sinon.stub();
+            connection[ADVISORY_STATE] = {
+                raw: {},
+                name: 'km_migration_ghost_test',
+            };
+
+            // Should resolve, not reject.
+            await locking.releaseAdvisoryLock(connection);
+            (connection[ADVISORY_STATE] === undefined).should.eql(true);
         });
     });
 });


### PR DESCRIPTION
ref https://linear.app/ghost/issue/PLA-256/add-mysql-locking-mechanism-via-get-lock-in-knex-migrator
- add connection-based locking helper for MySQL databases using GET_LOCK
- retain row-based migration lock fallback for SQLite