### PR TITLE
Restore pnpm supply-chain baseline

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,7 @@
-# Preserve the repo's existing install behavior; Renovate owns update timing.
-minimumReleaseAge: 0
+minimumReleaseAge: 4320
+strictDepBuilds: true
+blockExoticSubdeps: true
 
 allowBuilds:
-  better-sqlite3: true
+  better-sqlite3@12.11.1: true
   dtrace-provider: false


### PR DESCRIPTION
## What changed

- require dependencies to be at least 72 hours old with minimumReleaseAge: 4320
- fail closed when a dependency needs an unreviewed build with strictDepBuilds: true
- reject exotic transitive dependency sources with blockExoticSubdeps: true
- narrow the existing better-sqlite3 build approval to the exact lockfile version, 12.11.1
- preserve the existing package-wide denial for dtrace-provider

## Why

The repository explicitly disabled pnpm's package-age delay and allowed better-sqlite3 builds across every version. That leaves future dependency resolutions less constrained than Ghost's supply-chain baseline. These settings restore the cooldown and ensure only the reviewed lockfile version can execute its native install step.

Tracks [PLA-319](https://linear.app/ghost/issue/PLA-319/restore-the-pnpm-supply-chain-baseline-in-knex-migrator).

## Validation

- pnpm install --frozen-lockfile
- pnpm lint
- NODE_ENV=testing-better-sqlite3 pnpm coverage: 182 tests passed; 95.02% statements, 81.81% branches, 96.42% functions, 95% lines
- NODE_ENV=testing-better-sqlite3 pnpm test: 182 tests passed, including posttest lint
- pnpm pack --dry-run
- node bin/knex-migrator --help
- git diff --check

The PR's required CI matrix will also cover Node 22/24, MySQL, and the linked Ghost consumer smoke test.